### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]: "
+labels: bug
+assignees: LovelyBuggies
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+A clear and concise description of how this bug occurs.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/docs-improvements.md
+++ b/.github/ISSUE_TEMPLATE/docs-improvements.md
@@ -1,0 +1,20 @@
+---
+name: Docs improvements
+about: Describe the defects and expectations in docs
+title: "[DOCS]: "
+labels: documentation
+assignees: LovelyBuggies
+
+---
+
+## How do you want to improve the docs
+
+Report the typos and defects / Expect to new contents.
+
+## Where is the typos and defects
+
+EX. There is a typo ... in ...
+
+## What contents do you expect
+
+I look forward to ... in ...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]: "
+labels: enhancement
+assignees: LovelyBuggies
+
+---
+
+**Describe the problem, if any, that your feature request is related to**
+
+A clear and concise description of what the problem is.
+
+**Describe the feature you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives, if any, you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,12 @@
+---
+name: Support
+about: Describe your questions.
+title: "[SUPPORT]: "
+labels: question
+assignees: LovelyBuggies
+
+---
+
+## Describe your questions
+
+A clear and concise description of what your problem is.


### PR DESCRIPTION
For #11: It adds 4 most frequently used templates for issues: bug report, feature request, docs improvements, support. And they almost include all issue types in BH and Hist (*I think it would be nice if we put ToDo issues into [projects](https://github.com/scikit-hep/hist/projects)*).