### PR TITLE
nino/docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Hist'
-copyright = '2020, Scikit-HEP'
-author = 'Henry Schreiner and Nino Lau'
+project = "Hist"
+copyright = "2020, Scikit-HEP"
+author = "Henry Schreiner and Nino Lau"
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,19 +28,19 @@ author = 'Henry Schreiner and Nino Lau'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-	'sphinx.ext.autodoc',
-    'nbsphinx',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon'
+    "sphinx.ext.autodoc",
+    "nbsphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '**.ipynb_checkpoints', 'Thumbs.db', '.DS_Store', '.env']
+exclude_patterns = ["_build", "**.ipynb_checkpoints", "Thumbs.db", ".DS_Store", ".env"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -48,9 +48,9 @@ exclude_patterns = ['_build', '**.ipynb_checkpoints', 'Thumbs.db', '.DS_Store', 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Hist'
+copyright = '2020, Scikit-HEP'
+author = 'Henry Schreiner and Nino Lau'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+	'sphinx.ext.autodoc',
+    'nbsphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', '**.ipynb_checkpoints', 'Thumbs.db', '.DS_Store', '.env']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/development/dev.rst
+++ b/docs/source/development/dev.rst
@@ -1,0 +1,6 @@
+
+Development Guideline
+===========================
+
+
+

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -1,0 +1,11 @@
+.. _development:
+
+Development
+===========
+
+.. toctree::
+   :maxdepth: 4
+   :titlesonly:
+   :glob:
+
+   dev

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -1,0 +1,9 @@
+.. _examples:
+
+Examples
+========
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :glob:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,41 @@
+
+Welcome to Hist's documentation!
+================================
+
+
+Introduction
+------------
+
+`Hist <https://github.com/scikit-hep/hist>`_ is a powerful Histogramming tool for analysis based on `boost-histogram <https://boost-histogram.readthedocs.io/en/latest/index.html>`_ (the Python binding of the Histogram library in Boost). It is a friendly analysis-focused project that uses `boost-histogram <https://boost-histogram.readthedocs.io/en/latest/index.html>`_ as a backend to do the work, but provides plotting tools, shortcuts, and new ideas.
+
+To get an idea of creating histograms in Hist looks like, you can take a look at the :doc:`Examples <examples/index>`. Once you have a feel for what is involved in using Hist, we recommend you start by following the instructions in :doc:`Installation </installation/index>`. Then, go through the :doc:`User Guide </user-guide/index>`, and read the :doc:`Reference </reference/modules>` documentation. We value your contributions and you can follow the instructions in :doc:`Development </development/index>`. Finally, if you’re having problems, please do let us know at our :doc:`Support </support/index>` page.
+
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: Contents
+   :glob:
+
+   installation/index
+   user-guide/index
+   examples/index
+   development/index
+   support/index
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: API Reference
+   :glob:
+
+   reference/modules
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -1,0 +1,29 @@
+.. _installation:
+
+Installation
+============
+
+PyPI
+----------
+
+You can set up a development environment using PyPI.
+
+::
+
+   python3 -m venv .env            # Make a new environment in ./.env/
+   source .env/bin/activate        # Use the new environment
+   (.env)$ pip install -e .[dev]
+   (.env)$ python -m ipykernel install --user --name hist
+
+*You should have pip 10 or later*.
+
+Conda
+-----------
+
+You can also set up a development environment using Conda. With Conda, you can search some channels for development.
+
+::
+
+   $ conda env create -f dev-environment.yml -n hist
+   $ conda activate hist
+   (hist)$ python -m ipykernel install --name hist

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -1,0 +1,8 @@
+
+
+Hist API
+=================
+
+.. toctree::
+   :maxdepth: 2
+

--- a/docs/source/support/index.rst
+++ b/docs/source/support/index.rst
@@ -1,0 +1,12 @@
+.. _support:
+
+Support
+=======
+
+If you are stuck with a problem using Hist, please do get in touch at our `Issues <https://github.com/scikit-hep/hist/issues>`_.
+
+You can save time by following this procedure when reporting a problem:
+
+#. Do try to solve the problem on your own first. Read the documentation, including using the search feature, index and reference documentation.
+#. Search the issue archives to see if someone else already had the same problem.
+#. Before writing, try to create a minimal example that reproduces the problem. You’ll get the fastest response if you can send just a handful of lines of code that show what isn’t working.

--- a/docs/source/user-guide/index.rst
+++ b/docs/source/user-guide/index.rst
@@ -1,0 +1,9 @@
+.. _userguide:
+
+User Guide
+==========
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :glob:


### PR DESCRIPTION
`make html` under /docs folder to build docs. Considering the usage of hist is in flux, I cannot guarantee the correctness of original code snippet and Jupyter notebooks, so I have not provided `User Guide` and `Examples` up to now (though I can do this, there will be many fine-tunes). I plan to set aside some time for these docs at the end of GSoC. Then the doc could be both comprehensive and coherent. And it also helps me to recall back when writing my GSoC final article and maybe *presentation*. 