### PR TITLE
feat: support bh conversion

### DIFF
--- a/src/hist/axis.py
+++ b/src/hist/axis.py
@@ -3,8 +3,10 @@ from typing import Dict, List, Union
 
 import re
 import boost_histogram.axis as bha
+import hist.utils
 
 
+@hist.utils.set_family(hist.utils.HIST_FAMILY)
 class Regular(bha.Regular):
     def __init__(
         self,
@@ -108,6 +110,7 @@ class Boolean(bha.Regular):  # ToDo: should be derived from bha.Boolean
         self.metadata["title"] = value
 
 
+@hist.utils.set_family(hist.utils.HIST_FAMILY)
 class Variable(bha.Variable):
     def __init__(
         self,
@@ -163,6 +166,7 @@ class Variable(bha.Variable):
         self.metadata["title"] = value
 
 
+@hist.utils.set_family(hist.utils.HIST_FAMILY)
 class Integer(bha.Integer):
     def __init__(
         self,
@@ -220,6 +224,7 @@ class Integer(bha.Integer):
         self.metadata["title"] = value
 
 
+@hist.utils.set_family(hist.utils.HIST_FAMILY)
 class IntCategory(bha.IntCategory):
     def __init__(
         self,
@@ -269,6 +274,7 @@ class IntCategory(bha.IntCategory):
         self.metadata["title"] = value
 
 
+@hist.utils.set_family(hist.utils.HIST_FAMILY)
 class StrCategory(bha.StrCategory):
     def __init__(
         self,

--- a/src/hist/core.py
+++ b/src/hist/core.py
@@ -9,6 +9,7 @@ from scipy.optimize import curve_fit
 from uncertainties import correlated_values, unumpy
 from typing import Callable, Optional, Tuple, Union
 
+import hist.utils
 from .axis import Regular
 
 # typing alias
@@ -42,18 +43,18 @@ class always_normal_method:
         return self.method(self.instance, *args, **kwargs)
 
 
+@hist.utils.set_family(hist.utils.HIST_FAMILY)
 class BaseHist(bh.Histogram):
     def __init__(self, *args, **kwargs):
         """
             Initialize BaseHist object. Axis params can contain the names.
         """
         if len(args):
-            self._ax = list(args)
             super().__init__(*args, **kwargs)
             self.names: dict = dict()
             for ax in self.axes:
                 if ax.name and ax.name in self.names:
-                    raise Exception(
+                    raise KeyError(
                         f"{self.__class__.__name__} instance cannot contain axes with duplicated names."
                     )
                 else:

--- a/src/hist/utils.py
+++ b/src/hist/utils.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from boost_histogram.utils import set_family
+
+HIST_FAMILY = object()
+
+__all__ = ("HIST_FAMILY", "set_family")

--- a/tests/test_bh.py
+++ b/tests/test_bh.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import boost_histogram as bh
+import hist
+
+
+def test_bh_conversion():
+    h = bh.Histogram(bh.axis.Regular(3, 2, 1, metadata={"name": "x"}))
+
+    h2 = hist.Hist(h)
+
+    assert isinstance(h2.axes[0], hist.axis.Regular)
+    assert h2.axes[0].name == "x"
+    assert h2.axes[0].metadata == {"name": "x"}  # MAY CHANGE
+
+    h3 = bh.Histogram(h2)
+
+    assert not isinstance(h3.axes[0], hist.axis.Regular)
+    assert h3.axes[0].metadata == {"name": "x"}


### PR DESCRIPTION
Last important piece for Uproot demo.

For now, metadata is the raw metadata object, so users can change "title" and "name" there, and non-dict metadata is likely to be a problem. But should be fine for now.