### PR TITLE
fix: Support namedhist shortcut

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -52,9 +52,11 @@ class BaseHist(bh.Histogram):
         """
             Initialize BaseHist object. Axis params can contain the names.
         """
-        self._ax: List[Any] = []
+        # TODO: Make a base class type Axis for Hist
+        self._ax: List[bh.axis.Axis] = []
         self._hist: Any = None
         self._storage_proxy: Any = None
+        self.axes: NamedAxesTuple
 
         if len(args):
             self._hist = None

--- a/src/hist/namedhist.py
+++ b/src/hist/namedhist.py
@@ -11,10 +11,11 @@ class NamedHist(BaseHist):
         """
 
         super().__init__(*args, **kwargs)
-        if "" in self.axes.name:
-            raise Exception(
-                f"Each axes in the {self.__class__.__name__} instance should have a name"
-            )
+        if len(args):
+            if "" in self.axes.name:
+                raise RuntimeError(
+                    f"Each axes in the {self.__class__.__name__} instance should have a name"
+                )
 
     def project(self, *args: Union[int, str]):
         """

--- a/tests/test_named.py
+++ b/tests/test_named.py
@@ -801,7 +801,6 @@ def test_named_index_access():
         h[0:10:20j, 0:5:10j, "hello", False, 5]
 
 
-@pytest.mark.xfail  # ToDo: NamedHist's proxy should work
 def test_named_proxy():
     """
         Test named proxy -- whether NamedHist proxy works properly.


### PR DESCRIPTION
There should be a len check on all operations inside the histogram `__init__`, was missing from NamedHist.