### PR TITLE
feat: allow any name

### DIFF
--- a/src/hist/axis/__init__.py
+++ b/src/hist/axis/__init__.py
@@ -2,7 +2,6 @@
 from typing import Dict, List, Union, Any
 
 import sys
-import re
 import boost_histogram.axis as bha
 import hist.utils
 from hist.axestuple import NamedAxesTuple, ArrayTuple
@@ -84,14 +83,7 @@ class Regular(bha.Regular, AxesMixin):
         circular: bool = False,
         transform: bha.transform.Function = None
     ) -> None:
-        metadata: Dict = dict()
-        if not name:
-            metadata["name"] = ""
-        elif re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
-            metadata["name"] = name
-        else:
-            raise Exception("Name should be a valid Python identifier")
-        metadata["title"] = title
+        metadata: Dict[str, Any] = {"name": name or "", "title": title or ""}
         super().__init__(
             bins,
             start,
@@ -110,14 +102,7 @@ class Boolean(bha.Boolean, AxesMixin):
     __slots__ = ()
 
     def __init__(self, *, name: str = None, title: str = None) -> None:
-        metadata: Dict = dict()
-        if not name:
-            metadata["name"] = ""
-        elif re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
-            metadata["name"] = name
-        else:
-            raise Exception("Name should be a valid Python identifier")
-        metadata["title"] = title
+        metadata: Dict[str, Any] = {"name": name or "", "title": title or ""}
         super().__init__(metadata=metadata)
 
 
@@ -135,14 +120,7 @@ class Variable(bha.Variable, AxesMixin):
         overflow: bool = True,
         growth: bool = False
     ) -> None:
-        metadata: Dict = dict()
-        if not name:
-            metadata["name"] = ""
-        elif re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
-            metadata["name"] = name
-        else:
-            raise Exception("Name should be a valid Python identifier")
-        metadata["title"] = title
+        metadata: Dict[str, Any] = {"name": name or "", "title": title or ""}
         super().__init__(
             edges,
             metadata=metadata,
@@ -167,14 +145,7 @@ class Integer(bha.Integer, AxesMixin):
         overflow: bool = True,
         growth: bool = False
     ) -> None:
-        metadata: Dict = dict()
-        if not name:
-            metadata["name"] = ""
-        elif re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
-            metadata["name"] = name
-        else:
-            raise Exception("Name should be a valid Python identifier")
-        metadata["title"] = title
+        metadata: Dict[str, Any] = {"name": name or "", "title": title or ""}
         super().__init__(
             start,
             stop,
@@ -197,14 +168,7 @@ class IntCategory(bha.IntCategory, AxesMixin):
         title: str = None,
         growth: bool = False
     ) -> None:
-        metadata: Dict = dict()
-        if not name:
-            metadata["name"] = ""
-        elif re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
-            metadata["name"] = name
-        else:
-            raise Exception("Name should be a valid Python identifier")
-        metadata["title"] = title
+        metadata: Dict[str, Any] = {"name": name or "", "title": title or ""}
         super().__init__(categories, metadata=metadata, growth=growth)
 
 
@@ -220,12 +184,5 @@ class StrCategory(bha.StrCategory, AxesMixin):
         title: str = None,
         growth: bool = False
     ) -> None:
-        metadata: Dict = dict()
-        if not name:
-            metadata["name"] = ""
-        elif re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
-            metadata["name"] = name
-        else:
-            raise Exception("Name should be a valid Python identifier")
-        metadata["title"] = title
+        metadata: Dict[str, Any] = {"name": name or "", "title": title or ""}
         super().__init__(categories, metadata=metadata, growth=growth)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from hist import axis
-import pytest
 
 
 def test_axis_names():
@@ -21,60 +20,3 @@ def test_axis_names():
     assert axis.Integer(-3, 3, name="")
     assert axis.IntCategory(range(-3, 3), name="")
     assert axis.StrCategory("FT")
-
-    # protected or private prefix
-    with pytest.raises(Exception):
-        axis.Regular(50, -3, 3, name="_x")
-
-    with pytest.raises(Exception):
-        axis.Boolean(name="__x")
-
-    with pytest.raises(Exception):
-        axis.Variable(range(-3, 3), name="_x_")
-
-    with pytest.raises(Exception):
-        axis.Integer(-3, 3, name="_x0")
-
-    with pytest.raises(Exception):
-        axis.IntCategory(range(-3, 3), name="_0x")
-
-    with pytest.raises(Exception):
-        axis.StrCategory("FT", name="_xX")
-
-    # number prefix
-    with pytest.raises(Exception):
-        axis.Regular(50, -3, 3, name="0")
-
-    with pytest.raises(Exception):
-        axis.Boolean(name="00")
-
-    with pytest.raises(Exception):
-        axis.Variable(range(-3, 3), name="0x")
-
-    with pytest.raises(Exception):
-        axis.Integer(-3, 3, name="0_x")
-
-    with pytest.raises(Exception):
-        axis.IntCategory(range(-3, 3), name="00x")
-
-    with pytest.raises(Exception):
-        axis.StrCategory("FT", name="0xx")
-
-    # unsupported chr
-    with pytest.raises(Exception):
-        axis.Regular(50, -3, 3, name="-x")
-
-    with pytest.raises(Exception):
-        axis.Boolean(name="x-")
-
-    with pytest.raises(Exception):
-        axis.Variable(range(-3, 3), name="?x")
-
-    with pytest.raises(Exception):
-        axis.Integer(-3, 3, name="%x")
-
-    with pytest.raises(Exception):
-        axis.IntCategory(range(-3, 3), name="#x")
-
-    with pytest.raises(Exception):
-        axis.StrCategory("FT", name="*x")


### PR DESCRIPTION
These can still be used as strings, and through `**kwargs`, so better to allow more.

This also removes the ability to change the name, which I think uproot4 uses, so I'll restore before merging.