### PR TITLE
fix: fix kwargs in .fill() for WeightedMean&Mean storage

### DIFF
--- a/src/hist/namedhist.py
+++ b/src/hist/namedhist.py
@@ -30,7 +30,7 @@ class NamedHist(BaseHist):
             )
 
     def fill(
-        self, *args, weight=None, sample=None, thread: Optional[int] = None, **kwargs
+        self, *args, weight=None, sample=None, threads: Optional[int] = None, **kwargs
     ):
         """
             Insert data into the histogram using names and return a \
@@ -38,7 +38,9 @@ class NamedHist(BaseHist):
         """
 
         if len(kwargs) and all(isinstance(k, str) for k in kwargs.keys()):
-            return super().fill(*args, **kwargs)
+            return super().fill(
+                *args, weight=weight, sample=sample, threads=threads, **kwargs
+            )
 
         else:
             raise TypeError(

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -103,7 +103,7 @@ class ConstructProxy(QuickConstruct):
     def Int64(self) -> "BaseHist":
         return self.hist_class(*self.axes, storage=storage.Int64())
 
-    def AutomicInt64(self) -> "BaseHist":
+    def AtomicInt64(self) -> "BaseHist":
         return self.hist_class(*self.axes, storage=storage.AtomicInt64())
 
     def Weight(self) -> "BaseHist":

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -103,7 +103,7 @@ class ConstructProxy(QuickConstruct):
     def Int64(self) -> "BaseHist":
         return self.hist_class(*self.axes, storage=storage.Int64())
 
-    def AtomicInt64(self) -> "BaseHist":
+    def AutomicInt64(self) -> "BaseHist":
         return self.hist_class(*self.axes, storage=storage.AtomicInt64())
 
     def Weight(self) -> "BaseHist":

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -691,7 +691,7 @@ def test_base_index_access():
         h[0:10:20j, 0:5:10j, "hello", False, 5]
 
 
-class test_base_storage_proxy:
+class Test_base_storage_proxy:
     """
         Test base storage proxy suite -- whether BaseHist storage proxy \
         works properly.
@@ -699,8 +699,7 @@ class test_base_storage_proxy:
 
     def test_double(self):
         h = (
-            BaseHist()
-            .Reg(10, 0, 1, name="x")
+            BaseHist.new.Reg(10, 0, 1, name="x")
             .Reg(10, 0, 1, name="y")
             .Double()
             .fill(x=[0.5, 0.5], y=[0.2, 0.6])
@@ -708,23 +707,23 @@ class test_base_storage_proxy:
 
         assert h[0.5j, 0.2j] == 1
         assert h[bh.loc(0.5), bh.loc(0.6)] == 1
-        assert isinstance(h[0.5j, 0.5j], int)
+        assert isinstance(h[0.5j, 0.5j], float)
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Double()
 
     def test_int64(self):
-        h = BaseHist.Reg(10, 0, 1, name="x").Int64().fill([0.5, 0.5])
+        h = BaseHist.new.Reg(10, 0, 1, name="x").Int64().fill([0.5, 0.5])
         assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        assert isinstance(h[0.5j], int)
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Int64()
 
     def test_automic_int64(self):
-        h = BaseHist(axis.Regular(10, 0, 1, name="x")).AutomicInt64().fill([0.5, 0.5])
+        h = BaseHist.new.Reg(10, 0, 1, name="x").AutomicInt64().fill([0.5, 0.5])
         assert h[0.5j] == 2
         assert isinstance(h[0.5j], int)
 
@@ -733,36 +732,46 @@ class test_base_storage_proxy:
             h.AutomicInt64()
 
     def test_weight(self):
-        h = BaseHist.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = BaseHist.new.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])
+        assert h[0.5j].variance == 2
+        assert h[0.5j].value == 2
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Weight()
 
     def test_mean(self):
-        h = BaseHist(axis.Regular(10, 0, 1, name="x")).Mean().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = (
+            BaseHist.new.Reg(10, 0, 1, name="x")
+            .Mean()
+            .fill([0.5, 0.5], weight=[1, 1], sample=[1, 1])
+        )
+        assert h[0.5j].count == 2
+        assert h[0.5j].value == 1
+        assert h[0.5j].variance == 0
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Mean()
 
     def test_weighted_mean(self):
-        h = BaseHist.Reg(10, 0, 1, name="x").WeightedMean().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = (
+            BaseHist.new.Reg(10, 0, 1, name="x")
+            .WeightedMean()
+            .fill([0.5, 0.5], weight=[1, 1], sample=[1, 1])
+        )
+        assert h[0.5j].sum_of_weights == 2
+        assert h[0.5j].sum_of_weights_squared == 2
+        assert h[0.5j].value == 1
+        assert h[0.5j].variance == 0
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.WeightedMean()
 
     def test_unlimited(self):
-        h = BaseHist(axis.Regular(10, 0, 1, name="x")).Unlimited().fill([0.5, 0.5])
+        h = BaseHist.new.Reg(10, 0, 1, name="x").Unlimited().fill([0.5, 0.5])
         assert h[0.5j] == 2
-        assert isinstance(h[0.5j], any)
 
         # add storage to existing storage
         with pytest.raises(Exception):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -691,7 +691,7 @@ def test_base_index_access():
         h[0:10:20j, 0:5:10j, "hello", False, 5]
 
 
-class Test_base_storage_proxy:
+class TestBaseStorageProxy:
     """
         Test base storage proxy suite -- whether BaseHist storage proxy \
         works properly.
@@ -722,14 +722,14 @@ class Test_base_storage_proxy:
         with pytest.raises(Exception):
             h.Int64()
 
-    def test_automic_int64(self):
-        h = BaseHist.new.Reg(10, 0, 1, name="x").AutomicInt64().fill([0.5, 0.5])
+    def test_atomic_int64(self):
+        h = BaseHist.new.Reg(10, 0, 1, name="x").AtomicInt64().fill([0.5, 0.5])
         assert h[0.5j] == 2
         assert isinstance(h[0.5j], int)
 
         # add storage to existing storage
         with pytest.raises(Exception):
-            h.AutomicInt64()
+            h.AtomicInt64()
 
     def test_weight(self):
         h = BaseHist.new.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -697,7 +697,7 @@ def test_general_index_access():
     plt.close("all")
 
 
-class Test_general_storage_proxy:
+class TestGeneralStorageProxy:
     """
         Test general storage proxy suite -- whether Hist storage proxy \
         works properly.
@@ -728,14 +728,14 @@ class Test_general_storage_proxy:
         with pytest.raises(Exception):
             h.Int64()
 
-    def test_automic_int64(self):
-        h = Hist.new.Reg(10, 0, 1, name="x").AutomicInt64().fill([0.5, 0.5])
+    def test_atomic_int64(self):
+        h = Hist.new.Reg(10, 0, 1, name="x").AtomicInt64().fill([0.5, 0.5])
         assert h[0.5j] == 2
         assert isinstance(h[0.5j], int)
 
         # add storage to existing storage
         with pytest.raises(Exception):
-            h.AutomicInt64()
+            h.AtomicInt64()
 
     def test_weight(self):
         h = Hist.new.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -697,7 +697,7 @@ def test_general_index_access():
     plt.close("all")
 
 
-class test_general_storage_proxy:
+class Test_general_storage_proxy:
     """
         Test general storage proxy suite -- whether Hist storage proxy \
         works properly.
@@ -705,8 +705,7 @@ class test_general_storage_proxy:
 
     def test_double(self):
         h = (
-            Hist()
-            .Reg(10, 0, 1, name="x")
+            Hist.new.Reg(10, 0, 1, name="x")
             .Reg(10, 0, 1, name="y")
             .Double()
             .fill(x=[0.5, 0.5], y=[0.2, 0.6])
@@ -714,23 +713,23 @@ class test_general_storage_proxy:
 
         assert h[0.5j, 0.2j] == 1
         assert h[bh.loc(0.5), bh.loc(0.6)] == 1
-        assert isinstance(h[0.5j, 0.5j], int)
+        assert isinstance(h[0.5j, 0.5j], float)
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Double()
 
     def test_int64(self):
-        h = Hist.Reg(10, 0, 1, name="x").Int64().fill([0.5, 0.5])
+        h = Hist.new.Reg(10, 0, 1, name="x").Int64().fill([0.5, 0.5])
         assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        assert isinstance(h[0.5j], int)
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Int64()
 
     def test_automic_int64(self):
-        h = Hist(axis.Regular(10, 0, 1, name="x")).AutomicInt64().fill([0.5, 0.5])
+        h = Hist.new.Reg(10, 0, 1, name="x").AutomicInt64().fill([0.5, 0.5])
         assert h[0.5j] == 2
         assert isinstance(h[0.5j], int)
 
@@ -739,36 +738,46 @@ class test_general_storage_proxy:
             h.AutomicInt64()
 
     def test_weight(self):
-        h = Hist.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = Hist.new.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])
+        assert h[0.5j].variance == 2
+        assert h[0.5j].value == 2
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Weight()
 
     def test_mean(self):
-        h = Hist(axis.Regular(10, 0, 1, name="x")).Mean().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = (
+            Hist.new.Reg(10, 0, 1, name="x")
+            .Mean()
+            .fill([0.5, 0.5], weight=[1, 1], sample=[1, 1])
+        )
+        assert h[0.5j].count == 2
+        assert h[0.5j].value == 1
+        assert h[0.5j].variance == 0
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Mean()
 
     def test_weighted_mean(self):
-        h = Hist.Reg(10, 0, 1, name="x").WeightedMean().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = (
+            Hist.new.Reg(10, 0, 1, name="x")
+            .WeightedMean()
+            .fill([0.5, 0.5], weight=[1, 1], sample=[1, 1])
+        )
+        assert h[0.5j].sum_of_weights == 2
+        assert h[0.5j].sum_of_weights_squared == 2
+        assert h[0.5j].value == 1
+        assert h[0.5j].variance == 0
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.WeightedMean()
 
     def test_unlimited(self):
-        h = Hist(axis.Regular(10, 0, 1, name="x")).Unlimited().fill([0.5, 0.5])
+        h = Hist.new.Reg(10, 0, 1, name="x").Unlimited().fill([0.5, 0.5])
         assert h[0.5j] == 2
-        assert isinstance(h[0.5j], any)
 
         # add storage to existing storage
         with pytest.raises(Exception):

--- a/tests/test_named.py
+++ b/tests/test_named.py
@@ -438,7 +438,7 @@ def test_named_access():
         h[0j, -0j + 2, "hi", True]
 
 
-class test_named_storage_proxy:
+class Test_named_storage_proxy:
     """
         Test named storage proxy suite -- whether NamedHist storage proxy \
         works properly.
@@ -446,8 +446,7 @@ class test_named_storage_proxy:
 
     def test_double(self):
         h = (
-            NamedHist()
-            .Reg(10, 0, 1, name="x")
+            NamedHist.new.Reg(10, 0, 1, name="x")
             .Reg(10, 0, 1, name="y")
             .Double()
             .fill(x=[0.5, 0.5], y=[0.2, 0.6])
@@ -455,23 +454,23 @@ class test_named_storage_proxy:
 
         assert h[0.5j, 0.2j] == 1
         assert h[bh.loc(0.5), bh.loc(0.6)] == 1
-        assert isinstance(h[0.5j, 0.5j], int)
+        assert isinstance(h[0.5j, 0.5j], float)
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Double()
 
     def test_int64(self):
-        h = NamedHist.Reg(10, 0, 1, name="x").Int64().fill([0.5, 0.5])
+        h = NamedHist.new.Reg(10, 0, 1, name="x").Int64().fill(x=[0.5, 0.5])
         assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        assert isinstance(h[0.5j], int)
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Int64()
 
     def test_automic_int64(self):
-        h = NamedHist(axis.Regular(10, 0, 1, name="x")).AutomicInt64().fill([0.5, 0.5])
+        h = NamedHist.new.Reg(10, 0, 1, name="x").AutomicInt64().fill(x=[0.5, 0.5])
         assert h[0.5j] == 2
         assert isinstance(h[0.5j], int)
 
@@ -480,36 +479,46 @@ class test_named_storage_proxy:
             h.AutomicInt64()
 
     def test_weight(self):
-        h = NamedHist.Reg(10, 0, 1, name="x").Weight().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = NamedHist.new.Reg(10, 0, 1, name="x").Weight().fill(x=[0.5, 0.5])
+        assert h[0.5j].variance == 2
+        assert h[0.5j].value == 2
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Weight()
 
     def test_mean(self):
-        h = NamedHist(axis.Regular(10, 0, 1, name="x")).Mean().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = (
+            NamedHist.new.Reg(10, 0, 1, name="x")
+            .Mean()
+            .fill(x=[0.5, 0.5], weight=[1, 1], sample=[1, 1])
+        )
+        assert h[0.5j].count == 2
+        assert h[0.5j].value == 1
+        assert h[0.5j].variance == 0
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.Mean()
 
     def test_weighted_mean(self):
-        h = NamedHist.Reg(10, 0, 1, name="x").WeightedMean().fill([0.5, 0.5])
-        assert h[0.5j] == 2
-        assert isinstance(h[0.5j], float)
+        h = (
+            NamedHist.new.Reg(10, 0, 1, name="x")
+            .WeightedMean()
+            .fill(x=[0.5, 0.5], weight=[1, 1], sample=[1, 1])
+        )
+        assert h[0.5j].sum_of_weights == 2
+        assert h[0.5j].sum_of_weights_squared == 2
+        assert h[0.5j].value == 1
+        assert h[0.5j].variance == 0
 
         # add storage to existing storage
         with pytest.raises(Exception):
             h.WeightedMean()
 
     def test_unlimited(self):
-        h = NamedHist(axis.Regular(10, 0, 1, name="x")).Unlimited().fill([0.5, 0.5])
+        h = NamedHist.new.Reg(10, 0, 1, name="x").Unlimited().fill(x=[0.5, 0.5])
         assert h[0.5j] == 2
-        assert isinstance(h[0.5j], any)
 
         # add storage to existing storage
         with pytest.raises(Exception):

--- a/tests/test_named.py
+++ b/tests/test_named.py
@@ -438,7 +438,7 @@ def test_named_access():
         h[0j, -0j + 2, "hi", True]
 
 
-class Test_named_storage_proxy:
+class TestNamedStorageProxy:
     """
         Test named storage proxy suite -- whether NamedHist storage proxy \
         works properly.
@@ -469,14 +469,14 @@ class Test_named_storage_proxy:
         with pytest.raises(Exception):
             h.Int64()
 
-    def test_automic_int64(self):
-        h = NamedHist.new.Reg(10, 0, 1, name="x").AutomicInt64().fill(x=[0.5, 0.5])
+    def test_atomic_int64(self):
+        h = NamedHist.new.Reg(10, 0, 1, name="x").AtomicInt64().fill(x=[0.5, 0.5])
         assert h[0.5j] == 2
         assert isinstance(h[0.5j], int)
 
         # add storage to existing storage
         with pytest.raises(Exception):
-            h.AutomicInt64()
+            h.AtomicInt64()
 
     def test_weight(self):
         h = NamedHist.new.Reg(10, 0, 1, name="x").Weight().fill(x=[0.5, 0.5])


### PR DESCRIPTION
@henryiii Fix the error of "axis name could not be found" in

```python
h = NamedHist.new.Reg(10, 0, 1, name="x").WeightedMean().fill(x=[0.5, 0.5], weight=[1, 1], sample=[1, 1])
```

and allow TestClass to work (update `.new` proxy tests).