### PR TITLE
Use shutil.get_terminal_size instead of os.get_terminal_size

### DIFF
--- a/src/hist/classichist.py
+++ b/src/hist/classichist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-import os
+import shutil
 import argparse
 import hist
 import boost_histogram as bh
@@ -18,7 +18,7 @@ def main() -> None:
         "--screen-width",
         type=int,
         help="maximum screen width",
-        default=os.get_terminal_size()[0],
+        default=shutil.get_terminal_size()[0],
     )
     parser.add_argument("-t", "--label", type=str, help="label for plot")
     parser.add_argument("-o", "--output-image", type=str, help="save image to file")


### PR DESCRIPTION
`os.get_terminal_size` fail when there is no terminal connected (e.g. CI):

```
+ hist --help
Traceback (most recent call last):
  File "/home/conda/staged-recipes/build_artifacts/hist_1601700363608/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/hist", line 11, in <module>
    sys.exit(main())
  File "/home/conda/staged-recipes/build_artifacts/hist_1601700363608/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.7/site-packages/hist/classichist.py", line 21, in main
    default=os.get_terminal_size()[0],
OSError: [Errno 25] Inappropriate ioctl for device
```

Using `shutil.get_terminal_size` instead allows a fallback to be used instead of crashing.

See this build log from conda-forge for a demonstration:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=217306&view=logs&jobId=10bda42a-d420-5c28-a43f-bc4e66405e5c&j=10bda42a-d420-5c28-a43f-bc4e66405e5c&t=bef775d0-a1a2-55a3-9721-17147029baf0