### PR TITLE
Hist.plot_pull: more suitable bands in the pull bands 1sigma, 2 sigma, etc.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 IN PROGRESS
 -----------
 
-* `Hist.plot_pull` adapted to display the pulls by default in the range [-5,5]
+* `Hist.plot_pull`: more suitable bands in the pull bands 1sigma, 2 sigma, etc.
   `#102 <https://github.com/scikit-hep/hist/pull/102>`_
 
 * Fixed classichist's usage of `get_terminal_size` to support not running in a terminal

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@ Changelog
 IN PROGRESS
 -----------
 
+* `Hist.plot_pull` adapted to display the pulls by default in the range [-5,5]
+  `#102 <https://github.com/scikit-hep/hist/pull/102>`_
+
 * Fixed classichist's usage of `get_terminal_size` to support not running in a terminal
   `#99 <https://github.com/scikit-hep/hist/pull/99>`_
 

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -231,7 +231,7 @@ def plot_pull(
     width = (right_edge - left_edge) / len(pulls)
     pull_ax.bar(self.axes.centers[0], pulls, width=width, **bar_kwargs)
 
-    patch_height = 5. / pp_num
+    patch_height = max(np.abs(pulls)) / pp_num
     patch_width = width * len(pulls)
     for i in range(pp_num):
         # gradient color patches
@@ -252,7 +252,6 @@ def plot_pull(
         pull_ax.add_patch(downRect)
 
     plt.xlim(left_edge, right_edge)
-    plt.ylim(-5, 5)
 
     pull_ax.set_xlabel(self.axes[0].label)
     pull_ax.set_ylabel("Pull")

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -136,7 +136,7 @@ def plot_pull(
         from uncertainties import correlated_values, unumpy
     except ImportError:
         print(
-            "Hist requires scipy and uncertainties, please install hist[plot] or manually install dependencies",
+            "Hist.plot_pull requires scipy and uncertainties. Please install hist[plot] or manually install dependencies.",
             file=sys.stderr,
         )
         raise
@@ -203,7 +203,7 @@ def plot_pull(
 
     # patch plot keyword arguments
     pp_kwargs = _filter_dict(kwargs, "pp_", ignore={"pp_num"})
-    pp_num = kwargs.pop("pp_num", 3)
+    pp_num = kwargs.pop("pp_num", 5)
 
     # Judge whether some arguments are left
     if kwargs:
@@ -231,14 +231,14 @@ def plot_pull(
     width = (right_edge - left_edge) / len(pulls)
     pull_ax.bar(self.axes.centers[0], pulls, width=width, **bar_kwargs)
 
-    patch_height = max(np.abs(pulls)) / pp_num
+    patch_height = 5. / pp_num
     patch_width = width * len(pulls)
     for i in range(pp_num):
         # gradient color patches
         if "alpha" in pp_kwargs:
             pp_kwargs["alpha"] *= np.power(0.618, i)
         else:
-            pp_kwargs["alpha"] = 0.618 * np.power(0.618, i)
+            pp_kwargs["alpha"] = 0.5 * np.power(0.618, i)
 
         upRect_startpoint = (left_edge, i * patch_height)
         upRect = patches.Rectangle(
@@ -250,7 +250,9 @@ def plot_pull(
             downRect_startpoint, patch_width, patch_height, **pp_kwargs
         )
         pull_ax.add_patch(downRect)
+
     plt.xlim(left_edge, right_edge)
+    plt.ylim(-5, 5)
 
     pull_ax.set_xlabel(self.axes[0].label)
     pull_ax.set_ylabel("Pull")


### PR DESCRIPTION
I was playing with `Hist.plot_pull` and noticed that the range of the pulls is dynamic, meaning it is calculated from `max(np.abs(pulls)) / pp_num` in the code. This is not ideal since (1) pull plots are basically always displayed between -5 and 5, and (2) having several pull plots side-by-side would likely provide ranges on a plot-by-plot case, which is not ideal.

This little PR fixes the issue. It also makes sure that the colour bands by default are set at 1/2/.../5 sigma.

I will post an issue with some other matters related to the function.

Next week I will be giving some lectures and will be showing `Hist`. If at all possible it would be great to have this in a release :-).