### PR TITLE
boost-histogram and histoprint dependencies update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         python-version:
         - 3.6
         - 3.8
+        - 3.9
     name: Check Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
   hooks:
   - id: mypy
     files: ^src
+    additional_dependencies: ["numpy>=1.20", "matplotlib>=3.3"]
 
 - repo: https://github.com/mgedmin/check-manifest
   rev: "0.46"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,15 @@
 Changelog
 ====================
 
-IN PROGRESS
+Version 2.1.0
 --------------------
 
+Updated dependencies:
+
+- `boost-histogram` 0.11.0 to 0.13.0.
+    - major new features, including PlottableProtocol
+- `histoprint` >=1.4 to >=1.6.
+- `mplhep` >=0.2.16 when `[plot]` given
 
 
 Version 2.0.1

--- a/docs/user-guide/notebooks/SVGHistogram.ipynb
+++ b/docs/user-guide/notebooks/SVGHistogram.ipynb
@@ -185,7 +185,7 @@
     "    def _repr_svg_(self):\n",
     "        # This can be _repr_html_ instead, too - would make adding text easier/nicer\n",
     "        if self.ndim == 1:\n",
-    "            if not self.axes[0].options.circular:\n",
+    "            if not self.axes[0].traits.circular:\n",
     "                return plot_hist_1d(self)._repr_svg_()\n",
     "            else:\n",
     "                return plot_hist_1d_c(self)._repr_svg_()\n",
@@ -253,7 +253,7 @@
    "source": [
     "def plot_hist_1d(hi):\n",
     "    assert hi.ndim == 1\n",
-    "    assert not hi.axes[0].options.circular\n",
+    "    assert not hi.axes[0].traits.circular\n",
     "\n",
     "    if len(hi.axes[0]) > 40:\n",
     "        h = hi[:: bh.rebin(len(hi.axes[0]) // 20)]\n",
@@ -11246,7 +11246,7 @@
    "source": [
     "def plot_hist_1d_c(hi):\n",
     "    assert hi.ndim == 1\n",
-    "    assert hi.axes[0].options.circular\n",
+    "    assert hi.axes[0].traits.circular\n",
     "\n",
     "    if len(hi.axes[0]) > 40:\n",
     "        h = hi[:: bh.rebin(len(hi.axes[0]) // 20)]\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ classifiers =
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
-  Development Status :: 3 - Alpha
+  Programming Language :: Python :: 3.9
+  Development Status :: 4 - Beta
 
 
 [options]
@@ -38,8 +39,8 @@ include_package_data = True
 zip_safe = False
 install_requires =
   numpy >=1.13.3
-  boost-histogram ~=0.11.0
-  histoprint >=1.4
+  boost-histogram ~=0.13.0
+  histoprint >=1.6
   typing_extensions; python_version<"3.8"
 
 [options.entry_points]
@@ -58,19 +59,10 @@ check_untyped_defs = True
 [mypy-boost_histogram.*]
 ignore_missing_imports = True
 
-[mypy-matplotlib.*]
-ignore_missing_imports = True
-
 [mypy-histoprint]
 ignore_missing_imports = True
 
-[mypy-mplhep.*]
-ignore_missing_imports = True
-
 [mypy-scipy.optimize]
-ignore_missing_imports = True
-
-[mypy-numpy]
 ignore_missing_imports = True
 
 [mypy-uncertainties]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require["plot"] = [
     "matplotlib >=3.0",
     "scipy >=1.4",
     "uncertainties >=3",
-    "mplhep >=0.2.2",
+    "mplhep >=0.2.16",
 ]
 
 extras_require["test"] = [

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -59,7 +59,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor):
 
     def _repr_html_(self):
         if self.ndim == 1:
-            if self.axes[0].options.circular:
+            if self.axes[0].traits.circular:
                 return str(html_hist(self, svg_hist_1d_c))
             else:
                 return str(html_hist(self, svg_hist_1d))

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -20,6 +20,18 @@ if TYPE_CHECKING:
     import matplotlib.axes
 
 
+# Workaround for bug in mplhep
+def _proc_kw_for_lw(kwargs):
+    return {
+        f"{k[:-3]}_linestyle"
+        if k.endswith("_ls")
+        else "linestyle"
+        if k == "ls"
+        else k: v
+        for k, v in kwargs.items()
+    }
+
+
 @set_family(HIST_FAMILY)
 class BaseHist(bh.Histogram, metaclass=MetaConstructor):
     __slots__ = ()
@@ -218,7 +230,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor):
 
         import hist.plot
 
-        return hist.plot.histplot(self, ax=ax, **kwargs)
+        return hist.plot.histplot(self, ax=ax, **_proc_kw_for_lw(kwargs))
 
     def plot2d(
         self,
@@ -232,7 +244,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor):
 
         import hist.plot
 
-        return hist.plot.hist2dplot(self, ax=ax, **kwargs)
+        return hist.plot.hist2dplot(self, ax=ax, **_proc_kw_for_lw(kwargs))
 
     def plot2d_full(
         self,

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -21,6 +21,12 @@ except ImportError:
 __all__ = ("histplot", "hist2dplot", "plot2d_full", "plot_pull")
 
 
+def _expand_shortcuts(key: str) -> str:
+    if key == "ls":
+        return "linestyle"
+    return key
+
+
 def _filter_dict(
     dict: Dict[str, Any], prefix: str, *, ignore: Optional[Set[str]] = None
 ) -> Dict[str, Any]:
@@ -30,7 +36,7 @@ def _filter_dict(
     """
     ignore_set: Set[str] = ignore or set()
     return {
-        key[len(prefix) :]: dict.pop(key)
+        _expand_shortcuts(key[len(prefix) :]): dict.pop(key)
         for key in list(dict)
         if key.startswith(prefix) and key not in ignore_set
     }

--- a/src/hist/svgplots.py
+++ b/src/hist/svgplots.py
@@ -47,7 +47,7 @@ def svg_hist_1d(h):
     height = 100
 
     assert h.ndim == 1, "Must be 1D"
-    assert not h.axes[0].options.circular, "Must not be circular"
+    assert not h.axes[0].traits.circular, "Must not be circular"
 
     (edges,) = h.axes.edges
     norm_edges = (edges - edges[0]) / (edges[-1] - edges[0])
@@ -96,7 +96,7 @@ def svg_hist_1d_c(h):
     inner_radius = 20
 
     assert h.ndim == 1, "Must be 1D"
-    assert h.axes[0].options.circular, "Must be circular"
+    assert h.axes[0].traits.circular, "Must be circular"
 
     (edges,) = h.axes.edges
     norm_edges = (edges - edges[0]) / (edges[-1] - edges[0]) * np.pi * 2


### PR DESCRIPTION
Can this be released as 2.1.0 so that we get a consistent set of packages for the next `scikit-hep` metapackage release, see https://github.com/scikit-hep/scikit-hep/pull/133? Advance thanks.