### PR TITLE
feat: support data=

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Version 2.2.0
 * Support boost-histogram 1.0. Better plain reprs. Full Static Typing.
   `#137 <https://github.com/scikit-hep/hist/pull/137>`_
 
+* Support ``data=`` when construction a histogram to copy in initial data.
+  `#142 <https://github.com/scikit-hep/hist/pull/142>`_
+
 * Support ``Hist.from_columns``, for simple conversion of DataFrames and similar structures
   `#140 <https://github.com/scikit-hep/hist/pull/140>`_
 

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -61,6 +61,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         *args: Union[AxisProtocol, Storage, str, Tuple[int, float, float]],
         storage: Optional[Union[Storage, str]] = None,
         metadata: Any = None,
+        data: Optional[np.ndarray] = None,
     ) -> None:
         """
         Initialize BaseHist object. Axis params can contain the names.
@@ -96,6 +97,9 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
                 # label will return name if label is not set, so this is safe
                 if not ax.label:
                     ax.label = f"Axis {i}"
+
+        if data is not None:
+            self[...] = data  # type: ignore
 
     def _generate_axes_(self) -> NamedAxesTuple:
         """

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -821,3 +821,32 @@ def test_from_columns(named_hist):
 
     with pytest.raises(TypeError):
         named_hist.from_columns(columns, (axis.Integer(1, 5), "y"), weight="data")
+
+
+def test_from_array(named_hist):
+    h = Hist(
+        axis.Regular(10, 1, 2, name="A"),
+        axis.Regular(7, 1, 3, name="B"),
+        data=np.ones((10, 7)),
+    )
+    assert h.values() == approx(np.ones((10, 7)))
+    assert h.sum() == approx(70)
+    assert h.sum(flow=True) == approx(70)
+
+    h = Hist(
+        axis.Regular(10, 1, 2, name="A"),
+        axis.Regular(7, 1, 3, name="B"),
+        data=np.ones((12, 9)),
+    )
+
+    assert h.values(flow=False) == approx(np.ones((10, 7)))
+    assert h.values(flow=True) == approx(np.ones((12, 9)))
+    assert h.sum() == approx(70)
+    assert h.sum(flow=True) == approx(12 * 9)
+
+    with pytest.raises(ValueError):
+        h = Hist(
+            axis.Regular(10, 1, 2, name="A"),
+            axis.Regular(7, 1, 3, name="B"),
+            data=np.ones((11, 9)),
+        )


### PR DESCRIPTION
See scikit-hep/boost-histogram#421. This now supports setting `data=` on (normal) construction (not supported in QuickConstruct mode).
