### PR TITLE
refactor: allow gauss or gaus (ROOT style)

### DIFF
--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -266,7 +266,7 @@ def plot_pull(
     yerr = np.sqrt(variances)
 
     if isinstance(func, str):
-        if func == "gaus":
+        if func in {"gauss", "gaus"}:
             # gaussian with reasonable initial guesses for parameters
             constant = float(ydata.max())
             mean = (ydata * xdata).sum() / ydata.sum()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -235,9 +235,9 @@ def test_general_plot_pull():
 
     assert h.plot_pull(pdf_str)
 
-    assert h.plot_pull("gaus")
+    assert h.plot_pull("gauss")
 
-    assert h.plot_pull("gaus", likelihood=True)
+    assert h.plot_pull("gauss", likelihood=True)
 
     # dimension error
     hh = Hist(
@@ -534,9 +534,9 @@ def test_named_plot_pull():
 
     assert h.plot_pull(pdf_str)
 
-    assert h.plot_pull("gaus")
+    assert h.plot_pull("gauss")
 
-    assert h.plot_pull("gaus", likelihood=True)
+    assert h.plot_pull("gauss", likelihood=True)
 
     # dimension error
     hh = NamedHist(


### PR DESCRIPTION
Closes #157. Still accepting "guas" to allow ROOT style usage.
