### PR TITLE
feat: adding profile for COUNT -> MEAN conversion

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -310,7 +310,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         den_err = np.sqrt(np.sum(variances, axis=axis))
 
         new_values = num / den
-        new_variances = (num_err / den) ** 2 + (den_err * num / den ** 2) ** 2
+        new_variances = (num_err / den) ** 2 - (den_err * num / den ** 2) ** 2
 
         retval = self.__class__(*axes, storage=hist.storage.Mean())
         retval[...] = np.stack([count, new_values, new_variances], axis=-1)

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -309,8 +309,9 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         den = np.sum(values, axis=iaxis)
         den_err = np.sqrt(np.sum(variances, axis=iaxis))
 
-        new_values = num / den
-        new_variances = (num_err / den) ** 2 - (den_err * num / den ** 2) ** 2
+        with np.errstate(invalid="ignore"):
+            new_values = num / den
+            new_variances = (num_err / den) ** 2 - (den_err * num / den ** 2) ** 2
 
         retval = self.__class__(*axes, storage=hist.storage.Mean())
         retval[...] = np.stack([count, new_values, count * new_variances], axis=-1)

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -306,8 +306,8 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         num = np.tensordot(values, centers, ([iaxis], [0]))
         num_err = np.sqrt(np.tensordot(variances, centers ** 2, ([iaxis], [0])))
 
-        den = np.sum(values, axis=axis)
-        den_err = np.sqrt(np.sum(variances, axis=axis))
+        den = np.sum(values, axis=iaxis)
+        den_err = np.sqrt(np.sum(variances, axis=iaxis))
 
         new_values = num / den
         new_variances = (num_err / den) ** 2 - (den_err * num / den ** 2) ** 2

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -313,7 +313,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         new_variances = (num_err / den) ** 2 - (den_err * num / den ** 2) ** 2
 
         retval = self.__class__(*axes, storage=hist.storage.Mean())
-        retval[...] = np.stack([count, new_values, new_variances], axis=-1)
+        retval[...] = np.stack([count, new_values, count*new_variances], axis=-1)
         return retval
 
     def density(self) -> np.ndarray:

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -313,7 +313,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         new_variances = (num_err / den) ** 2 - (den_err * num / den ** 2) ** 2
 
         retval = self.__class__(*axes, storage=hist.storage.Mean())
-        retval[...] = np.stack([count, new_values, count*new_variances], axis=-1)
+        retval[...] = np.stack([count, new_values, count * new_variances], axis=-1)
         return retval
 
     def density(self) -> np.ndarray:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -597,6 +597,7 @@ def test_general_transform_proxy():
         Hist.new.Sqrt(3, -4, 25)
 
     h1 = Hist.new.Log(4, 1, 10_000).Log(3, 1 / 1_000, 1).Double()
+
     h1.fill([2, 11, 101, 1_001], [1 / 999, 1 / 99, 1 / 9, 1 / 9])
     assert h1[0, 0] == 1
     assert h1[1, 1] == 1
@@ -604,11 +605,11 @@ def test_general_transform_proxy():
     assert h1[3, 2] == 1
 
     # Missing arguments
-    with pytest.raises(Exception):
-        Hist.new.Regular(4, 1, 10_000).Log()
+    with pytest.raises(TypeError):
+        Hist.new.Reg(4, 1, 10_000).Log()
 
-    # wrong value
-    with pytest.raises(Exception):
+    # Wrong value
+    with pytest.raises(ValueError):
         Hist.new.Log(3, -1, 10_000)
 
     h2 = Hist.new.Pow(24, 1, 5, power=2).Pow(124, 1, 5, power=3).Int64()
@@ -636,25 +637,28 @@ def test_general_transform_proxy():
             4, 1, 5, forward=ftype(np.log), inverse=ftype(np.exp)
         )
     ).Int64()
+
     h3.fill([1, 2, 3, 4], [1, 2, 3, 4])
     assert h3[0, 0] == 1
     assert h3[1, 1] == 1
     assert h3[2, 2] == 1
     assert h3[3, 3] == 1
 
-    # wrong value
-    with pytest.raises(Exception):
-        Hist().Regular(24, 1, 5).Func(ftype(math.log), ftype(math.exp))
+    # wrong args
+    with pytest.raises(TypeError):
+        Hist.new.Reg(24, 1, 5).Func(ftype(math.log), ftype(math.exp))
 
-    # wrong value
-    assert Hist.new.Func(
-        4, -1, 5, forward=ftype(math.log), inverse=ftype(math.log)
-    ).Double()
-    with pytest.raises(Exception):
-        Hist.new.Func(4, -1, 5, forward=ftype(np.log), inverse=ftype(np.log))
+    # wrong value raises uncatchable warning
+    # Hist.new.Func(
+    #     4, -1, 5, forward=ftype(math.log), inverse=ftype(math.log)
+    # ).Double()
+
+    with pytest.raises(ValueError):
+        with pytest.warns(RuntimeWarning):
+            Hist.new.Func(4, -1, 5, forward=ftype(np.log), inverse=ftype(np.log))
 
     # lack args
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         Hist.new.Func(4, 1, 5)
 
 

--- a/tests/test_named.py
+++ b/tests/test_named.py
@@ -649,12 +649,12 @@ def test_named_transform_proxy():
     assert h1[2, 2] == 1
     assert h1[3, 2] == 1
 
-    # wrong value
-    with pytest.raises(Exception):
-        NamedHist.new.Regular(4, 1, 10_000, name="x").Log()
+    # wrong arguments
+    with pytest.raises(TypeError):
+        NamedHist.new.Reg(4, 1, 10_000, name="x").Log()
 
     # wrong value
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         NamedHist.new.Log(3, -1, 10_000, name="x")
 
     h2 = (
@@ -669,15 +669,15 @@ def test_named_transform_proxy():
     assert h2[15, 63] == 1
 
     # based on existing axis
-    with pytest.raises(Exception):
-        NamedHist.new.Regular(24, 1, 5, name="x").Pow(2)
+    with pytest.raises(TypeError):
+        NamedHist.new.Reg(24, 1, 5, name="x").Pow(2)
 
     # wrong value
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         NamedHist.new.Pow(24, -1, 5, power=1 / 2, name="x")
 
     # lack args
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         NamedHist.new.Pow(24, 1, 5, name="x")
 
     ftype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
@@ -695,20 +695,22 @@ def test_named_transform_proxy():
     assert h3[3, 3] == 1
 
     # based on existing axis
-    with pytest.raises(Exception):
-        NamedHist.new.Regular(24, 1, 5, name="x").Func(ftype(math.log), ftype(math.exp))
+    with pytest.raises(TypeError):
+        NamedHist.new.Reg(24, 1, 5, name="x").Func(ftype(math.log), ftype(math.exp))
 
-    # wrong value
-    assert NamedHist.new.Func(
-        4, -1, 5, name="x", forward=ftype(math.log), inverse=ftype(math.log)
-    )
-    with pytest.raises(Exception):
-        NamedHist.new.Func(
-            4, -1, 5, name="x", forward=ftype(np.log), inverse=ftype(np.log)
-        )
+    # Uncatchable warning
+    # assert NamedHist.new.Func(
+    #     4, -1, 5, name="x", forward=ftype(math.log), inverse=ftype(math.log)
+    # )
+
+    with pytest.raises(ValueError):
+        with pytest.warns(RuntimeWarning):
+            NamedHist.new.Func(
+                4, -1, 5, name="x", forward=ftype(np.log), inverse=ftype(np.log)
+            )
 
     # lack args
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         NamedHist.new.Func(4, 1, 5, name="x")
 
 
@@ -720,7 +722,7 @@ def test_named_hist_proxy():
     h = NamedHist.new.Reg(10, 0, 1, name="x").Double().fill(x=[0.5, 0.5])
     assert h[0.5j] == 2
 
-    assert type(h) == NamedHist
+    assert type(h) is NamedHist
 
     with pytest.raises(AttributeError):
         NamedHist().new

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,35 @@
+import numpy as np
+from pytest import approx
+
+import hist
+
+
+def test_example():
+    xy = np.array(
+        [
+            [-2, 1.5],
+            [-2, -3.5],
+            [-2, 1.5],  # x = -2
+            [0.0, -2.0],
+            [0.0, -2.0],
+            [0.0, 0.0],
+            [0.0, 2.0],
+            [0.0, 4.0],  # x = 0
+            [2, 1.5],  # x = +2
+        ]
+    )
+    h = hist.Hist(
+        hist.axis.Regular(5, -5, 5, name="x"), hist.axis.Regular(5, -5, 5, name="y")
+    ).fill(*xy.T)
+
+    # Profile out the y-axis
+    hp = h.profile("y")
+
+    # Exclude edge bins since no values from above will fall into them
+    # When there are values there, ROOT does something funky in those bins,
+    # despite these bins not being in the axis that is profiled out, and
+    # despite there being no overflow... to be understood.
+    assert hp.values()[1:-1] == approx(np.array([0.0, 0.4, 2.0]))
+    assert hp.variances()[1:-1] == approx(
+        np.array([2.66666667, 1.088, float("nan")]), nan_ok=True
+    )


### PR DESCRIPTION
Closes #156, adds a `.profile` method. Based heavily on @aminnj's example.


TODO:
* [x] Needs tests
* This probably could be a WeightedMean, probably give a choice? Just got the basics working for now. (Can revisit later)
* [x] Should hide or handle warnings (true for some of our tests, too)


Followup:
* histoprint should handle showing kind=MEAN histograms (it doesn't like the NaN's, I think) CC @ast0815 (edit: done!)
* mplhep should show a better plot style for kind=MEAN, and should also ensure it handles kind=MEAN's requirements (we could also dispatch differently, but the best fix would be in mplhep) CC @andrzejnovak
* Boost-histogram should describe accumulators/storages a bit more in the docs, especially setting with a stack, including the correct order. CC Me

If kind=MEAN, you are only supposed to plot variances if `counts() > 1`, and values if `counts() >= 1`.
