### PR TITLE
fix: cleaner IPython import completion for Python 3.7+

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ IN PROGRESS
 * Add ``fit_fmt=`` to ``plot_pull`` to control display of fit params.
   `#168 <https://github.com/scikit-hep/hist/pull/168>`_
 
+* Cleaner IPython completion for Python 3.7+.
+  `#179 <https://github.com/scikit-hep/hist/pull/179>`_
+
+
 Version 2.2.1
 --------------------
 

--- a/src/hist/__init__.py
+++ b/src/hist/__init__.py
@@ -3,7 +3,9 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/hist for details.
 
+import warnings
 from types import ModuleType
+from typing import Tuple
 
 from . import accumulators, axis, numpy, storage, tag
 from .basehist import BaseHist
@@ -34,8 +36,12 @@ __all__ = (
 
 
 # Python 3.7 only
+def __dir__() -> Tuple[str, ...]:
+    return __all__
+
+
+# Python 3.7 only
 def __getattr__(name: str) -> ModuleType:
-    import warnings
 
     if name == "axes":
         msg = f"Misspelling error, '{name}' should be 'axis'"

--- a/src/hist/axestuple.py
+++ b/src/hist/axestuple.py
@@ -5,6 +5,10 @@ from boost_histogram.axis import ArrayTuple, AxesTuple
 __all__ = ("NamedAxesTuple", "AxesTuple", "ArrayTuple")
 
 
+def __dir__() -> Tuple[str, ...]:
+    return __all__
+
+
 class NamedAxesTuple(AxesTuple):
     __slots__ = ()
 

--- a/src/hist/axis/__init__.py
+++ b/src/hist/axis/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import boost_histogram.axis as bha
 
@@ -26,6 +26,10 @@ __all__ = (
     "NamedAxesTuple",
     "ArrayTuple",
 )
+
+
+def __dir__() -> Tuple[str, ...]:
+    return __all__
 
 
 class CoreAxisProtocol(Protocol):

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -23,6 +23,10 @@ except ModuleNotFoundError:
 __all__ = ("histplot", "hist2dplot", "plot2d_full", "plot_pull", "plot_pie")
 
 
+def __dir__() -> Tuple[str, ...]:
+    return __all__
+
+
 def _expand_shortcuts(key: str) -> str:
     if key == "ls":
         return "linestyle"

--- a/src/hist/tag.py
+++ b/src/hist/tag.py
@@ -1,5 +1,3 @@
-__all__ = ("Slicer", "Locator", "at", "loc", "overflow", "underflow", "rebin", "sum")
-
 from boost_histogram.tag import (
     Locator,
     Slicer,
@@ -10,3 +8,5 @@ from boost_histogram.tag import (
     sum,
     underflow,
 )
+
+__all__ = ("Slicer", "Locator", "at", "loc", "overflow", "underflow", "rebin", "sum")

--- a/src/hist/typing.py
+++ b/src/hist/typing.py
@@ -1,5 +1,5 @@
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol, SupportsIndex
@@ -15,3 +15,7 @@ else:
 
 
 __all__ = ("Protocol", "SupportsIndex", "Ufunc", "ArrayLike")
+
+
+def __dir__() -> Tuple[str, ...]:
+    return __all__


### PR DESCRIPTION
I’ve used Python 3.7 module-level `__getattr__`  for a while now to allow mistyping hist.axis import as hist.axes to show a warning but work anyway. However, I completely missed a fantastic usage for Python 3.7 module-level `__dir__ `: you can “fix” IPython’s tab completion to just show the items in `__all__`! Wow! One of the main things that bugged me about importing and defining unrelated things in modules, and one reason that boost-histogram has an `_internal` module. It was almost a parenthetical comment on the classic article here:  https://snarky.ca/lazy-importing-in-python-3-7/



