### PR TITLE
docs: Revise plot_ratio and plot_pull API examples in user guide

### DIFF
--- a/docs/user-guide/notebooks/Plots.ipynb
+++ b/docs/user-guide/notebooks/Plots.ipynb
@@ -200,19 +200,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from uncertainties import unumpy as unp\n",
-    "\n",
-    "\n",
     "def pdf(x, a=1 / np.sqrt(2 * np.pi), x0=0, sigma=1, offset=0):\n",
-    "    exp = unp.exp if a.dtype == np.dtype(\"O\") else np.exp\n",
-    "    return a * exp(-((x - x0) ** 2) / (2 * sigma ** 2)) + offset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*(The uncertainty is non-significant as we filled a great quantities of observation points above.)*"
+    "    return a * np.exp(-((x - x0) ** 2) / (2 * sigma ** 2)) + offset"
    ]
   },
   {
@@ -221,58 +210,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(10, 8))\n",
-    "\n",
-    "hh = hist.Hist(\n",
-    "    hist.axis.Regular(\n",
-    "        50, -5, 5, name=\"X\", label=\"x [units]\", underflow=False, overflow=False\n",
-    "    )\n",
-    ").fill(np.random.normal(size=100))\n",
-    "\n",
-    "ax, pull_ax = hh.plot_pull(\n",
-    "    pdf,\n",
-    "    eb_ecolor=\"steelblue\",\n",
-    "    eb_mfc=\"steelblue\",\n",
-    "    eb_mec=\"steelblue\",\n",
-    "    eb_fmt=\"o\",\n",
-    "    eb_ms=6,\n",
-    "    eb_capsize=1,\n",
-    "    eb_capthick=2,\n",
-    "    eb_alpha=0.8,\n",
-    "    fp_c=\"hotpink\",\n",
-    "    fp_ls=\"-\",\n",
-    "    fp_lw=2,\n",
-    "    fp_alpha=0.8,\n",
-    "    bar_fc=\"royalblue\",\n",
-    "    pp_num=3,\n",
-    "    pp_fc=\"royalblue\",\n",
-    "    pp_alpha=0.618,\n",
-    "    pp_ec=None,\n",
-    "    ub_alpha=0.2,\n",
-    ")\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Via Plot Ratio\n",
-    "\n",
-    "You can also make an arbitrary ratio plot using the `.plot_ratio` API:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def pdf(x, a=1 / np.sqrt(2 * np.pi), x0=0, sigma=1, offset=0):\n",
-    "    return a * np.exp(-((x - x0) ** 2) / (2 * sigma ** 2)) + offset\n",
-    "\n",
-    "\n",
     "np.random.seed(0)\n",
     "\n",
     "hist_1 = hist.Hist(\n",
@@ -280,14 +217,9 @@
     "        50, -5, 5, name=\"X\", label=\"x [units]\", underflow=False, overflow=False\n",
     "    )\n",
     ").fill(np.random.normal(size=1000))\n",
-    "hist_2 = hist.Hist(\n",
-    "    hist.axis.Regular(\n",
-    "        50, -5, 5, name=\"X\", label=\"x [units]\", underflow=False, overflow=False\n",
-    "    )\n",
-    ").fill(np.random.normal(size=1700))\n",
     "\n",
     "fig = plt.figure(figsize=(10, 8))\n",
-    "artists = hist_1.plot_pull(\n",
+    "main_ax_artists, sublot_ax_arists = hist_1.plot_pull(\n",
     "    \"normal\",\n",
     "    eb_ecolor=\"steelblue\",\n",
     "    eb_mfc=\"steelblue\",\n",
@@ -307,7 +239,16 @@
     "    pp_alpha=0.618,\n",
     "    pp_ec=None,\n",
     "    ub_alpha=0.2,\n",
-    ");"
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Via Plot Ratio\n",
+    "\n",
+    "You can also make an arbitrary ratio plot using the `.plot_ratio` API:"
    ]
   },
   {
@@ -316,14 +257,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "hist_2 = hist.Hist(\n",
+    "    hist.axis.Regular(\n",
+    "        50, -5, 5, name=\"X\", label=\"x [units]\", underflow=False, overflow=False\n",
+    "    )\n",
+    ").fill(np.random.normal(size=1700))\n",
+    "\n",
     "fig = plt.figure(figsize=(10, 8))\n",
-    "hist_1.plot_ratio(\n",
+    "main_ax_artists, sublot_ax_arists = hist_1.plot_ratio(\n",
     "    hist_2,\n",
     "    rp_ylabel=r\"Ratio\",\n",
     "    rp_num_label=\"hist1\",\n",
     "    rp_denom_label=\"hist2\",\n",
-    "    rp_uncert_draw_type=\"bar\",\n",
-    ");"
+    "    rp_uncert_draw_type=\"bar\",  # line or bar\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ratios between the histogram and a callable, or `str` alias, are supported as well"
    ]
   },
   {
@@ -333,7 +287,7 @@
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(10, 8))\n",
-    "hist_1.plot_ratio(pdf);"
+    "main_ax_artists, sublot_ax_arists = hist_1.plot_ratio(pdf)"
    ]
   }
  ],

--- a/docs/user-guide/notebooks/Plots.ipynb
+++ b/docs/user-guide/notebooks/Plots.ipynb
@@ -191,7 +191,7 @@
    "source": [
     "## Via Plot Pull\n",
     "\n",
-    "Pull plot is commonly used in HEP studies, we provide a method for this specific type of plot called `.plot_pull()`, where you can pass in a Callable object and then we could fit it on the plot."
+    "Pull plots are commonly used in HEP studies, and we provide a method for them with `.plot_pull()`, which accepts a `Callable` object, like the below `pdf` function, which is then fit to the histogram and the fit and pulls are shown on the plot. As Normal distributions are the generally desired function to fit the histogram data, the `str` aliases `\"normal\"`, `\"gauss\"`, and `\"gaus\"` are supported as well."
    ]
   },
   {
@@ -260,7 +260,7 @@
    "source": [
     "## Via Plot Ratio\n",
     "\n",
-    "You can also make an arbitrary ratio plot, like so (starting with plot pull, then using plot ratio):"
+    "You can also make an arbitrary ratio plot using the `.plot_ratio` API:"
    ]
   },
   {


### PR DESCRIPTION
Resolves #188

This PR revised the Plot notebook in the user's guide to note the return structure of both `plot_ratio` and `plot_pull` is a tuple of matplotlib artists and to expand on the use of both callables and `str` aliases in both APIs.

Relevant section of RTD preview: https://hist--190.org.readthedocs.build/en/190/user-guide/notebooks/Plots.html#Via-Plot-Pull