### PR TITLE
fix: empty display (0 size axes) shouldn't try to plot

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -116,7 +116,9 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         return NamedAxesTuple(self._axis(i) for i in range(self.ndim))
 
     def _repr_html_(self) -> str:
-        if self.ndim == 1:
+        if self.size == 0:
+            return str(self)
+        elif self.ndim == 1:
             if self.axes[0].traits.circular:
                 return str(html_hist(self, svg_hist_1d_c))
             else:
@@ -125,6 +127,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
             return str(html_hist(self, svg_hist_2d))
         elif self.ndim > 2:
             return str(html_hist(self, svg_hist_nd))
+
         return str(self)
 
     def _name_to_index(self, name: str) -> int:

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -163,9 +163,9 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
                     raise TypeError(
                         f"{ax} must be all int or strings if axis not given"
                     )
+            elif not ax.name or ax.name not in data:
+                raise TypeError("All axes must have names present in the data")
             else:
-                if not ax.name or ax.name not in data:
-                    raise TypeError("All axes must have names present in the data")
                 axes_list.append(ax)
 
         weight_arr = data[weight] if weight else None
@@ -236,15 +236,15 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         Convert some specific indices to step.
         """
 
-        if isinstance(x, complex):
-            if x.real != 0:
-                raise ValueError("The step should not have real part")
-            elif x.imag % 1 != 0:
-                raise ValueError("The imaginary part should be an integer")
-            else:
-                return bh.rebin(int(x.imag))
-        else:
+        if not isinstance(x, complex):
             return x
+
+        if x.real != 0:
+            raise ValueError("The step should not have real part")
+        elif x.imag % 1 != 0:
+            raise ValueError("The imaginary part should be an integer")
+        else:
+            return bh.rebin(int(x.imag))
 
     def _index_transform(self, index: IndexingExpr) -> bh.IndexingExpr:
         """

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -846,3 +846,24 @@ def test_from_array(named_hist):
             axis.Regular(7, 1, 3, name="B"),
             data=np.ones((11, 9)),
         )
+
+
+def test_sum_empty_axis():
+    hist = bh.Histogram(
+        bh.axis.StrCategory("", growth=True),
+        bh.axis.Regular(10, 0, 1),
+        storage=bh.storage.Weight(),
+    )
+    assert hist.sum().value == 0
+    assert "Str" in repr(hist)
+
+
+def test_sum_empty_axis_hist():
+    h = Hist(
+        axis.StrCategory("", growth=True),
+        axis.Regular(10, 0, 1),
+        storage=storage.Weight(),
+    )
+    assert h.sum().value == 0
+    assert "Str" in repr(h)
+    h._repr_html_()


### PR DESCRIPTION
This might be the only problem causing the segfault, though I thought I saw it in bh::fill. Doing `np.max([])` is undefined.

Fixes #215