### PR TITLE
feat: axis sort

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -1,5 +1,5 @@
 import functools
-import inspect 
+import inspect
 import operator
 import typing
 import warnings
@@ -229,7 +229,6 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         total_data = tuple(args) + tuple(data)  # Python 2 can't unpack twice
         return super().fill(*total_data, weight=weight, sample=sample, threads=threads)
 
-    
     def sort(
         self: T,
         axis: Union[int, str],
@@ -240,29 +239,34 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         name = axis
         pos = [i for i in range(len(self.axes)) if self.axes[name] == self.axes[i]][0]
         ixes = sorted(range(len(self.axes[name])), key=lambda k: self.axes[name][k])
-        
+
         def copy_traits(axis, instance=hist.axis.StrCategory):
             trait_dict = vars(axis.traits)
             for key in list(trait_dict.keys()):
                 if key not in inspect.signature(instance).parameters.keys():
                     del trait_dict[key]
-            trait_dict['name'] = axis.name
-            trait_dict['label'] = axis.label
+            trait_dict["name"] = axis.name
+            trait_dict["label"] = axis.label
             return trait_dict
 
         labels = [list(self.axes[pos])[i] for i in ixes]
         if isinstance(self.axes[pos], hist.axis.IntCategory):
-            new_ax = hist.axis.IntCategory(labels, **copy_traits(self.axes[pos], hist.axis.IntCategory))
+            new_ax = hist.axis.IntCategory(
+                labels, **copy_traits(self.axes[pos], hist.axis.IntCategory)
+            )
         elif isinstance(self.axes[pos], hist.axis.StrCategory):
-            new_ax = hist.axis.StrCategory(labels, **copy_traits(self.axes[pos], hist.axis.StrCategory))
+            new_ax = hist.axis.StrCategory(
+                labels, **copy_traits(self.axes[pos], hist.axis.StrCategory)
+            )
         else:
             raise RuntimeError("Expected a categorical axis")
-            
-        new_h = hist.Hist(*self.axes[:pos], new_ax, *self.axes[pos+1:])
 
-        new_h[...] = self.view(flow=True)[(slice(None),) * pos + (ixes,) + (slice(None),) * (len(self.axes) - pos - 1)]
+        new_h = hist.Hist(*self.axes[:pos], new_ax, *self.axes[pos + 1 :])
+
+        new_h[...] = self.view(flow=True)[
+            (slice(None),) * pos + (ixes,) + (slice(None),) * (len(self.axes) - pos - 1)
+        ]
         return new_h
-
 
     def _loc_shortcut(self, x: Any) -> Any:
         """

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -1,4 +1,5 @@
 import functools
+import inspect 
 import operator
 import typing
 import warnings
@@ -227,6 +228,41 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
 
         total_data = tuple(args) + tuple(data)  # Python 2 can't unpack twice
         return super().fill(*total_data, weight=weight, sample=sample, threads=threads)
+
+    
+    def sort(
+        self: T,
+        axis: Union[int, str],
+    ) -> Union[T, float, bh.accumulators.Accumulator]:
+        """
+        Sort a categorical axis.
+        """
+        name = axis
+        pos = [i for i in range(len(self.axes)) if self.axes[name] == self.axes[i]][0]
+        ixes = sorted(range(len(self.axes[name])), key=lambda k: self.axes[name][k])
+        
+        def copy_traits(axis, instance=hist.axis.StrCategory):
+            trait_dict = vars(axis.traits)
+            for key in list(trait_dict.keys()):
+                if key not in inspect.signature(instance).parameters.keys():
+                    del trait_dict[key]
+            trait_dict['name'] = axis.name
+            trait_dict['label'] = axis.label
+            return trait_dict
+
+        labels = [list(self.axes[pos])[i] for i in ixes]
+        if isinstance(self.axes[pos], hist.axis.IntCategory):
+            new_ax = hist.axis.IntCategory(labels, **copy_traits(self.axes[pos], hist.axis.IntCategory))
+        elif isinstance(self.axes[pos], hist.axis.StrCategory):
+            new_ax = hist.axis.StrCategory(labels, **copy_traits(self.axes[pos], hist.axis.StrCategory))
+        else:
+            raise RuntimeError("Expected a categorical axis")
+            
+        new_h = hist.Hist(*self.axes[:pos], new_ax, *self.axes[pos+1:])
+
+        new_h[...] = self.view(flow=True)[(slice(None),) * pos + (ixes,) + (slice(None),) * (len(self.axes) - pos - 1)]
+        return new_h
+
 
     def _loc_shortcut(self, x: Any) -> Any:
         """

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -896,3 +896,11 @@ def test_select_by_index_imag():
 
     assert tuple(h[[2, 1]].axes[0]) == (9, 8)
     assert tuple(h[[8j, 7j]].axes[0]) == (8, 7)
+
+
+def test_sorted_simple():
+    h = Hist.new.IntCat([4, 1, 2]).Double()
+    assert tuple(h.sort(0).axes[0]) == (1, 2, 4)
+    assert tuple(h.sort(0, reverse=True).axes[0]) == (4, 2, 1)
+    assert tuple(h.sort(0, key=lambda x: -x).axes[0]) == (4, 2, 1)
+    assert tuple(h.sort(0, key=lambda x: -x, reverse=True).axes[0]) == (1, 2, 4)


### PR DESCRIPTION
When completed, closes #222 

To implement:
- sort by passing index
- sort by passing lambda to sorted
- add tests

@henryiii could you take a look? I had to abuse some design decisions of hist to get this work, so maybe you can recommend better workarounds. 
- AxisNamedTuple (and I assume axes) as well cannot be assigned to, so I had to recreate the sorted axis
- Couldn't easily copy all meta/traits from old axis to new - hence the helper with inspect (name/label don't seem to be part of traits/metadata) - also cannot create axis and edit metadata

Here is a couple of examples 
2D - yax
![image](https://user-images.githubusercontent.com/13226500/122921521-e0667980-d362-11eb-90c8-149ec9df658c.png)
2D - xax
![image](https://user-images.githubusercontent.com/13226500/122921357-ac8b5400-d362-11eb-85f1-67370e0fed44.png)
1D
![image](https://user-images.githubusercontent.com/13226500/122921493-d93f6b80-d362-11eb-98c9-8c05a1e1228d.png)
3D - sort on not-projected axis
![image](https://user-images.githubusercontent.com/13226500/122921554-e9efe180-d362-11eb-80f7-340c1c7a53f5.png)
