### PR TITLE
feat: support full names and mistaken usage for QuickConstruct

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -80,6 +80,14 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
             storage = args[-1]
             args = args[:-1]
 
+        # Support raw Quick Construct being accidentally passed in
+        args = [
+            a.axes[0]  # type: ignore
+            if isinstance(a, hist.quick_construct.ConstructProxy) and len(a.axes) == 1
+            else a
+            for a in args
+        ]
+
         if args:
             if isinstance(storage, str):
                 storage_str = storage.title()

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -27,7 +27,7 @@ class QuickConstruct:
         self.hist_class = hist_class
         self.axes = axes
 
-    def Reg(
+    def Regular(
         self,
         bins: int,
         start: float,
@@ -62,6 +62,8 @@ class QuickConstruct:
                 __dict__=__dict__,
             ),
         )
+
+    Reg = Regular
 
     def Sqrt(
         self,
@@ -170,7 +172,7 @@ class QuickConstruct:
             ),
         )
 
-    def Bool(
+    def Boolean(
         self,
         name: str = "",
         label: str = "",
@@ -188,7 +190,9 @@ class QuickConstruct:
             ),
         )
 
-    def Var(
+    Bool = Boolean
+
+    def Variable(
         self,
         edges: Iterable[float],
         *,
@@ -219,7 +223,9 @@ class QuickConstruct:
             ),
         )
 
-    def Int(
+    Var = Variable
+
+    def Integer(
         self,
         start: int,
         stop: int,
@@ -252,7 +258,9 @@ class QuickConstruct:
             ),
         )
 
-    def IntCat(
+    Int = Integer
+
+    def IntCategory(
         self,
         categories: Iterable[int],
         *,
@@ -274,6 +282,8 @@ class QuickConstruct:
                 growth=growth,
             ),
         )
+
+    IntCat = IntCategory
 
     def StrCat(
         self,
@@ -297,6 +307,8 @@ class QuickConstruct:
                 growth=growth,
             ),
         )
+
+    StrCategory = StrCat
 
 
 class ConstructProxy(QuickConstruct):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -746,6 +746,13 @@ def test_hist_proxy():
     assert h["T", "F"] == 1
 
 
+def test_hist_proxy_mistake():
+    h = Hist(Hist.new.IntCat(range(10)))
+    h2 = Hist.new.IntCategory(range(10)).Double()
+
+    assert h == h2
+
+
 def test_general_density():
     """
     Test general density -- whether Hist density work properly.


### PR DESCRIPTION
This address #251 by adding full names too; the mistake I was worried about, a user doing this:

```python
Hist(Hist.new.Regular(10,0,1))
```

is much less likely now that we have the ".new" part (before we didn't), and if someone does make that mistake, mypy will complain - and if they don't type check it, it will just work anyway! :)
