### PR TITLE
feat: Add "efficiency" option to rp_uncertainty_type kwarg

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Version 2.5.0
 * Dropped Python 3.6 support.
   `#194 <https://github.com/scikit-hep/hist/pull/194>`_
 
+* Add ``"efficiency"`` ``uncertainty_type`` option alias for ``ratio_plot`` API.
+  `#266 <https://github.com/scikit-hep/hist/pull/266>`_
 
 
 Version 2.4.0

--- a/docs/user-guide/notebooks/Plots.ipynb
+++ b/docs/user-guide/notebooks/Plots.ipynb
@@ -289,6 +289,35 @@
     "fig = plt.figure(figsize=(10, 8))\n",
     "main_ax_artists, sublot_ax_arists = hist_1.plot_ratio(pdf)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the `.plot_ratio` API you can also make efficiency plots (where the numerator is a strict subset of the denominator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_3 = hist_2.copy() * 0.7\n",
+    "hist_2.fill(np.random.uniform(-5, 5, 600))\n",
+    "hist_3.fill(np.random.uniform(-5, 5, 200))\n",
+    "\n",
+    "fig = plt.figure(figsize=(10, 8))\n",
+    "main_ax_artists, sublot_ax_arists = hist_3.plot_ratio(\n",
+    "    hist_2,\n",
+    "    rp_ylabel=\"Efficiency\",\n",
+    "    rp_num_label=\"hist3\",\n",
+    "    rp_denom_label=\"hist2\",\n",
+    "    rp_uncert_draw_type=\"line\",\n",
+    "    rp_uncertainty_type=\"poisson-ratio\",  # or \"efficiency\"\n",
+    "    rp_ylim=[0, 1.1],\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/src/hist/intervals.py
+++ b/src/hist/intervals.py
@@ -113,7 +113,7 @@ def clopper_pearson_interval(
 def ratio_uncertainty(
     num: np.ndarray,
     denom: np.ndarray,
-    uncertainty_type: Literal["poisson", "poisson-ratio"] = "poisson",
+    uncertainty_type: Literal["poisson", "poisson-ratio", "efficiency"] = "poisson",
 ) -> Any:
     r"""
     Calculate the uncertainties for the values of the ratio ``num/denom`` using
@@ -128,6 +128,7 @@ def ratio_uncertainty(
          numerator scaled by the denominator.
          ``"poisson-ratio"`` implements the Clopper-Pearson interval for Poisson
          distributed ``num`` and ``denom``.
+         ``"efficiency"`` is an alias for ``"poisson-ratio"``.
 
     Returns:
         The uncertainties for the ratio.
@@ -137,7 +138,7 @@ def ratio_uncertainty(
         ratio = num / denom
     if uncertainty_type == "poisson":
         ratio_uncert = np.abs(poisson_interval(ratio, num / np.square(denom)) - ratio)
-    elif uncertainty_type == "poisson-ratio":
+    elif uncertainty_type in {"poisson-ratio", "efficiency"}:
         # poisson ratio n/m is equivalent to binomial n/(n+m)
         ratio_uncert = np.abs(clopper_pearson_interval(num, num + denom) - ratio)
     else:


### PR DESCRIPTION
Resolves #195

Add an `"efficiency"` option to `ratio_uncertainty`'s `uncertainty_type` kwarg that acts as an alias for the `poisson-ratio` option. Additionally add an example of making an efficiency plot to the user guide.