### PR TITLE
fix: Use proper Clopper-Pearson interval for efficiency ratio

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,9 @@ Version 2.5.0
 * Dropped Python 3.6 support.
   `#194 <https://github.com/scikit-hep/hist/pull/194>`_
 
-* Add ``"efficiency"`` ``uncertainty_type`` option alias for ``ratio_plot`` API.
+* Add ``"efficiency"`` ``uncertainty_type`` option for ``ratio_plot`` API.
   `#266 <https://github.com/scikit-hep/hist/pull/266>`_
+  `#278 <https://github.com/scikit-hep/hist/pull/278>`_
 
 
 Version 2.4.0

--- a/docs/user-guide/notebooks/Plots.ipynb
+++ b/docs/user-guide/notebooks/Plots.ipynb
@@ -310,12 +310,10 @@
     "fig = plt.figure(figsize=(10, 8))\n",
     "main_ax_artists, sublot_ax_arists = hist_3.plot_ratio(\n",
     "    hist_2,\n",
-    "    rp_ylabel=\"Efficiency\",\n",
     "    rp_num_label=\"hist3\",\n",
     "    rp_denom_label=\"hist2\",\n",
     "    rp_uncert_draw_type=\"line\",\n",
     "    rp_uncertainty_type=\"efficiency\",\n",
-    "    rp_ylim=[0, 1.1],\n",
     ")"
    ]
   }

--- a/docs/user-guide/notebooks/Plots.ipynb
+++ b/docs/user-guide/notebooks/Plots.ipynb
@@ -314,7 +314,7 @@
     "    rp_num_label=\"hist3\",\n",
     "    rp_denom_label=\"hist2\",\n",
     "    rp_uncert_draw_type=\"line\",\n",
-    "    rp_uncertainty_type=\"poisson-ratio\",  # or \"efficiency\"\n",
+    "    rp_uncertainty_type=\"efficiency\",\n",
     "    rp_ylim=[0, 1.1],\n",
     ")"
    ]

--- a/src/hist/intervals.py
+++ b/src/hist/intervals.py
@@ -128,7 +128,9 @@ def ratio_uncertainty(
          numerator scaled by the denominator.
          ``"poisson-ratio"`` implements the Clopper-Pearson interval for Poisson
          distributed ``num`` and ``denom``.
-         ``"efficiency"`` is an alias for ``"poisson-ratio"``.
+         ``"efficiency"`` implements the Clopper-Pearson interval for Poisson
+         distributed ``num`` and ``denom``, with ``denom`` assumed to be a
+         strict subset of ``num``.
 
     Returns:
         The uncertainties for the ratio.
@@ -138,9 +140,11 @@ def ratio_uncertainty(
         ratio = num / denom
     if uncertainty_type == "poisson":
         ratio_uncert = np.abs(poisson_interval(ratio, num / np.square(denom)) - ratio)
-    elif uncertainty_type in {"poisson-ratio", "efficiency"}:
-        # poisson ratio n/m is equivalent to binomial n/(n+m)
+    elif uncertainty_type == "poisson-ratio":
         ratio_uncert = np.abs(clopper_pearson_interval(num, num + denom) - ratio)
+    elif uncertainty_type == "efficiency":
+        # poisson ratio n/m is equivalent to binomial n/(n+m)
+        ratio_uncert = np.abs(clopper_pearson_interval(num, denom) - ratio)
     else:
         raise TypeError(
             f"'{uncertainty_type}' is an invalid option for uncertainty_type."

--- a/src/hist/intervals.py
+++ b/src/hist/intervals.py
@@ -127,7 +127,8 @@ def ratio_uncertainty(
          ``"poisson"`` (default) implements the Poisson interval for the
          numerator scaled by the denominator.
          ``"poisson-ratio"`` implements the Clopper-Pearson interval for Poisson
-         distributed ``num`` and ``denom``.
+         distributed ``num`` and ``denom`` where it is assumed that ``num`` and
+         ``denom`` are independent.
          ``"efficiency"`` implements the Clopper-Pearson interval for Poisson
          distributed ``num`` and ``denom``, with ``num`` assumed to be a
          strict subset of ``denom``.

--- a/src/hist/intervals.py
+++ b/src/hist/intervals.py
@@ -129,8 +129,8 @@ def ratio_uncertainty(
          ``"poisson-ratio"`` implements the Clopper-Pearson interval for Poisson
          distributed ``num`` and ``denom``.
          ``"efficiency"`` implements the Clopper-Pearson interval for Poisson
-         distributed ``num`` and ``denom``, with ``denom`` assumed to be a
-         strict subset of ``num``.
+         distributed ``num`` and ``denom``, with ``num`` assumed to be a
+         strict subset of ``denom``.
 
     Returns:
         The uncertainties for the ratio.

--- a/src/hist/intervals.py
+++ b/src/hist/intervals.py
@@ -141,9 +141,9 @@ def ratio_uncertainty(
     if uncertainty_type == "poisson":
         ratio_uncert = np.abs(poisson_interval(ratio, num / np.square(denom)) - ratio)
     elif uncertainty_type == "poisson-ratio":
+        # poisson ratio n/m is equivalent to binomial n/(n+m)
         ratio_uncert = np.abs(clopper_pearson_interval(num, num + denom) - ratio)
     elif uncertainty_type == "efficiency":
-        # poisson ratio n/m is equivalent to binomial n/(n+m)
         ratio_uncert = np.abs(clopper_pearson_interval(num, denom) - ratio)
     else:
         raise TypeError(

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -574,6 +574,9 @@ def _plot_ratiolike(
     rp_kwargs.setdefault("legend_loc", "best")
     rp_kwargs.setdefault("num_label", None)
     rp_kwargs.setdefault("denom_label", None)
+    if rp_kwargs["uncertainty_type"] == "efficiency":
+        rp_kwargs.setdefault("ylabel", "Efficiency")
+        rp_kwargs.setdefault("ylim", [0, 1.1])
 
     # patch plot keyword arguments
     pp_kwargs = _filter_dict(kwargs, "pp_")

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -150,7 +150,7 @@ def test_valid_efficiency_ratio_uncertainty(hist_fixture):
     """
 
     hist_1, _ = hist_fixture
-    num = hist_1.copy().values()
+    num = hist_1.values()
     den = num
 
     efficiency_ratio = num / den

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -141,3 +141,22 @@ def test_ratio_uncertainty(hist_fixture):
         intervals.ratio_uncertainty(
             hist_1.values(), hist_2.values(), uncertainty_type="fail"
         )
+
+
+def test_valid_efficiency_ratio_uncertainty(hist_fixture):
+    """
+    Test that the upper bound for the error interval does not exceed unity
+    for efficiency ratio plots.
+    """
+
+    hist_1, _ = hist_fixture
+    num = hist_1.copy().values()
+    den = num
+
+    efficiency_ratio = num / den
+    _, uncertainty_max = intervals.ratio_uncertainty(
+        num, den, uncertainty_type="efficiency"
+    )
+    efficiency_err_up = efficiency_ratio + uncertainty_max
+
+    assert len(efficiency_err_up[efficiency_err_up > 1.0]) == 0


### PR DESCRIPTION
Fixes #277.

```
* Use the correct Clopper-Pearson interval for an efficiency ratio as for efficiency numerator is subset of denominator
   - Update docstring to reflect this
* Add default values for ratio plot ylabel and ylim if `efficiency` option used
* Correct efficiency plot example in user guide
* Add test to ensure no uncertainties are above 1
```