### PR TITLE
chore: update noxfile.py to drop Python 3.6

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9"]
+ALL_PYTHONS = ["3.7", "3.8", "3.9"]
 
 nox.options.sessions = ["lint", "tests"]
 


### PR DESCRIPTION
Removes Python 3.6 from `noxfile.py`