### PR TITLE
chore: bump setuptools (for setuptools_scm)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["wheel", "setuptools>=42", "setuptools_scm[toml]>=3.4"]
+requires = ["wheel", "setuptools>=45", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Should be building with setuptools_scm 6.3.0