### PR TITLE
chore: Use `black-jupyter` pre-commit hook over `nbqa-black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,6 @@ repos:
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.1.0
   hooks:
-  - id: nbqa-black
-    additional_dependencies: [black==20.8b1]
   - id: nbqa-pyupgrade
     additional_dependencies: [pyupgrade==2.12.0]
     args: ["--py37-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 - repo: https://github.com/psf/black
   rev: 21.8b0
   hooks:
-  - id: black
+  - id: black-jupyter
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   rev: 1.1.0
   hooks:
   - id: nbqa-pyupgrade
-    additional_dependencies: [pyupgrade==2.12.0]
+    additional_dependencies: [pyupgrade==2.25.0]
     args: ["--py37-plus"]
 
 - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
As noted in https://github.com/scikit-hep/hist/pull/276#issuecomment-912956178 there is now a `black[jupyter]` extra that allows for Black to run on Jupyter notebooks. `nbqa-black` does this, but Marco Gorelli contributed this functionality to Black so now the `black-jupyter` hook will be the equivalent hook as running `black` and `nbqa-black`.

c.f. https://github.com/scikit-hep/pyhf/pull/1598 for more details / an example


**Suggested squash and merge commit message**
```
* Use jupyter-black pre-commit hook id from Black
   - black-jupyter will run on Python and pyi files, so it replaces the black hook id as well
* Remove nbqa-black pre-commit hook from nbQA
   - Marco Gorelli essentially contributed nbqa-black to Black in the form of jupyter-black
* Update the pyupgrade version used as an additional_dependencies to match that of the pyupgrade hook
```