### PR TITLE
docs: fix typo in changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,7 +46,7 @@ Smaller features or fixes:
 * Use NumPy 1.21 for static typing.
   [#285](https://github.com/scikit-hep/hist/pull/285)
 * Support running tests without plotting requirements.
-  [#321](https://github.com/scikit-hep/hist/pull/321>)
+  [#321](https://github.com/scikit-hep/hist/pull/321)
 
 ## Version 2.4.0
 


### PR DESCRIPTION
- Fix broken link due to `>` character at the end