### PR TITLE
Fix `ax` arg being ignored by `plot_stack()`

### DIFF
--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -727,7 +727,7 @@ def plot_stack(
         if all(h.name is not None for h in self):
             kwargs["label"] = [h.name for h in self]
 
-    ret = histplot(list(self), **kwargs)
+    ret = histplot(list(self), ax=ax, **kwargs)
     ax = ret[0].stairs.axes
     _plot_keywords_wrapper(ax, legend=legend)
 


### PR DESCRIPTION
The `ax`-argument in `plot_stack` wasn't given to the internally called `histplot` function and then `ax` was overwritten with the axis in the return value of `histplot`. Instead, the argument should be forwarded.