### PR TITLE
Allow for irregular bin widths in `hist.plot.plot_pull_array`

### DIFF
--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -494,12 +494,12 @@ def plot_pull_array(
     right_edge = __hist.axes.edges[-1][-1]
 
     # Pull: plot the pulls using Matplotlib bar method
-    width = (right_edge - left_edge) / len(pulls)
-    bar_artists = ax.bar(x_values, pulls, width=width, **bar_kwargs)
+    bin_widths = __hist.axes[0].widths
+    bar_artists = ax.bar(x_values, pulls, width=bin_widths, **bar_kwargs)
 
     pp_num = pp_kwargs.pop("num", 5)
     patch_height = max(np.abs(pulls)) / pp_num
-    patch_width = width * len(pulls)
+    patch_width = right_edge - left_edge
     patch_artists = []
     for i in range(pp_num):
         # gradient color patches


### PR DESCRIPTION
Assuming the axis has an `edges` attribute, I assume it should also have a `widths` attribute, so I thought we can just use that for the pull bar widths instead of calculating our own assuming a regular spacing (which might not be true).

For the patch-width, we just use `right_edge - left_edge`, instead of what was done before, which dividing this difference by the number of pulls and then multiplying them again with the same number.

From git-blame it looks like @matthewfeickert had written the original function so I might mention him.

I should also mention I'm not using this function, I just looked at it because I was writing my own pull plot function and was considering adapting the code for the rectangular patches and then just wondered why `hist.axes[0].widths` isn't used. Thus, it would be good if this could be tested properly.