### PR TITLE
docs: fix link and cleanup demo

### DIFF
--- a/docs/examples/HistDemo.ipynb
+++ b/docs/examples/HistDemo.ipynb
@@ -290,9 +290,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hist",
+   "display_name": "hist2",
    "language": "python",
-   "name": "hist"
+   "name": "hist2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -304,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/examples/HistDemo.ipynb
+++ b/docs/examples/HistDemo.ipynb
@@ -286,20 +286,13 @@
    "source": [
     "mplhep.hist2dplot(h2);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hist2",
+   "display_name": "hist",
    "language": "python",
-   "name": "hist2"
+   "name": "hist"
   },
   "language_info": {
    "codemirror_mode": {
@@ -311,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Introduction
 
 `Hist <https://github.com/scikit-hep/hist>`_ is a powerful Histogramming tool for analysis based on `boost-histogram <https://boost-histogram.readthedocs.io/en/latest/index.html>`_ (the Python binding of the Histogram library in Boost). It is a friendly analysis-focused project that uses `boost-histogram <https://boost-histogram.readthedocs.io/en/latest/index.html>`_ as a backend to do the work, but provides plotting tools, shortcuts, and new ideas.
 
-To get an idea of creating histograms in Hist looks like, you can take a look at the :doc:`Examples <examples/index>`. Once you have a feel for what is involved in using Hist, we recommend you start by following the instructions in :doc:`Installation <installation>`. Then, go through the :doc:`User Guide </user-guide/index>`, and read the :doc:`Reference </reference/modules>` documentation. We value your contributions and you can follow the instructions in :doc:`Contributing <contributing>`. Finally, if you’re having problems, please do let us know at our :doc:`Support <support>` page.
+To get an idea of creating histograms in Hist looks like, you can take a look at the :doc:`Examples <examples/HistDemo>`. Once you have a feel for what is involved in using Hist, we recommend you start by following the instructions in :doc:`Installation <installation>`. Then, go through the :doc:`User Guide </user-guide/index>`, and read the :doc:`Reference </reference/modules>` documentation. We value your contributions and you can follow the instructions in :doc:`Contributing <contributing>`. Finally, if you’re having problems, please do let us know at our :doc:`Support <support>` page.
 
 
 .. toctree::


### PR DESCRIPTION
- Fix link for `Examples` in `index`
- Remove empty cell in example