### PR TITLE
docs: fix link in index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Introduction
 
 `Hist <https://github.com/scikit-hep/hist>`_ is a powerful Histogramming tool for analysis based on `boost-histogram <https://boost-histogram.readthedocs.io/en/latest/index.html>`_ (the Python binding of the Histogram library in Boost). It is a friendly analysis-focused project that uses `boost-histogram <https://boost-histogram.readthedocs.io/en/latest/index.html>`_ as a backend to do the work, but provides plotting tools, shortcuts, and new ideas.
 
-To get an idea of creating histograms in Hist looks like, you can take a look at the :doc:`Examples <examples/HistDemo>`. Once you have a feel for what is involved in using Hist, we recommend you start by following the instructions in :doc:`Installation <installation>`. Then, go through the :doc:`User Guide </user-guide/index>`, and read the :doc:`Reference </reference/modules>` documentation. We value your contributions and you can follow the instructions in :doc:`Contributing <contributing>`. Finally, if you’re having problems, please do let us know at our :doc:`Support <support>` page.
+To get an idea of creating histograms in Hist looks like, you can take a look at the :doc:`Examples <examples/HistDemo>`. Once you have a feel for what is involved in using Hist, we recommend you start by following the instructions in :doc:`Installation <installation>`. Then, go through the User Guide starting with :doc:`Quickstart </user-guide/quickstart>`, and read the :doc:`Reference </reference/modules>` documentation. We value your contributions and you can follow the instructions in :doc:`Contributing <contributing>`. Finally, if you’re having problems, please do let us know at our :doc:`Support <support>` page.
 
 
 .. toctree::

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -9,7 +9,7 @@ help.
 You can save time by following this procedure when reporting a problem:
 
 * Do try to solve the problem on your own first. Read the documentation,
-  including using the search feature, index and reference documentation
+  including using the search feature, index and reference documentation.
 * Search the issue archives to see if someone else already had the same
   problem.
 * Before writing, try to create a minimal example that reproduces


### PR DESCRIPTION
- Fix link for `Quickstart` in index
- Add missing `.`