### PR TITLE
feat: Add Binder support 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include tests *.py *.png
 recursive-include src *.py
 recursive-include src *.pyi
 recursive-include src py.typed
+recursive-exclude binder *

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 [![GitHub Discussion][github-discussions-badge]][github-discussions-link]
 [![Gitter][gitter-badge]][gitter-link]
+[![Binder][binder-badge]][binder-link]
 [![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
 
 Hist is an analyst-friendly front-end for
@@ -176,6 +177,8 @@ Support for this work was provided by the National Science Foundation cooperativ
 
 [actions-badge]:            https://github.com/scikit-hep/hist/workflows/CI/badge.svg
 [actions-link]:             https://github.com/scikit-hep/hist/actions
+[binder-badge]:             https://mybinder.org/badge_logo.svg
+[binder-link]:              https://mybinder.org/v2/gh/scikit-hep/hist/HEAD
 [black-badge]:              https://img.shields.io/badge/code%20style-black-000000.svg
 [black-link]:               https://github.com/psf/black
 [conda-badge]:              https://img.shields.io/conda/vn/conda-forge/hist

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+python -m pip install --upgrade .[plot]
+python -m pip install uncertainties


### PR DESCRIPTION
Add Binder support by using the [postBuild configuration file](https://mybinder.readthedocs.io/en/latest/using/config_files.html) to install the required dependencies needed by the user guide notebooks.  Additionally, add a launch Binder badge to the README.

preview on this branch: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/scikit-hep/hist/docs/add-binder-support)