### PR TITLE
docs: fix the structure of API docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ To get an idea of creating histograms in Hist looks like, you can take a look at
    examples/HistDemo
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 6
    :titlesonly:
    :caption: API Reference
    :glob:

--- a/docs/reference/hist.accumulators.rst
+++ b/docs/reference/hist.accumulators.rst
@@ -1,0 +1,7 @@
+hist.accumulators module
+========================
+
+.. automodule:: hist.accumulators
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.axestuple.rst
+++ b/docs/reference/hist.axestuple.rst
@@ -1,0 +1,7 @@
+hist.axestuple module
+=====================
+
+.. automodule:: hist.axestuple
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.axis.rst
+++ b/docs/reference/hist.axis.rst
@@ -5,7 +5,7 @@ Submodules
 ----------
 
 hist.axis.transform module
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: hist.axis.transform
    :members:

--- a/docs/reference/hist.basehist.rst
+++ b/docs/reference/hist.basehist.rst
@@ -1,0 +1,7 @@
+hist.basehist module
+====================
+
+.. automodule:: hist.basehist
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.classichist.rst
+++ b/docs/reference/hist.classichist.rst
@@ -1,0 +1,7 @@
+hist.classichist module
+=======================
+
+.. automodule:: hist.classichist
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.hist.rst
+++ b/docs/reference/hist.hist.rst
@@ -1,0 +1,7 @@
+hist.hist module
+================
+
+.. automodule:: hist.hist
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.intervals.rst
+++ b/docs/reference/hist.intervals.rst
@@ -1,0 +1,7 @@
+hist.intervals module
+=====================
+
+.. automodule:: hist.intervals
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.namedhist.rst
+++ b/docs/reference/hist.namedhist.rst
@@ -1,0 +1,7 @@
+hist.namedhist module
+=====================
+
+.. automodule:: hist.namedhist
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.numpy.rst
+++ b/docs/reference/hist.numpy.rst
@@ -1,0 +1,7 @@
+hist.numpy module
+=================
+
+.. automodule:: hist.numpy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.rst
+++ b/docs/reference/hist.rst
@@ -5,113 +5,25 @@ Subpackages
 -----------
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 5
 
    hist.axis
 
 Submodules
 ----------
 
-hist.accumulators module
-------------------------
+.. toctree::
+   :maxdepth: 1
 
-.. automodule:: hist.accumulators
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.axestuple module
----------------------
-
-.. automodule:: hist.axestuple
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.basehist module
---------------------
-
-.. automodule:: hist.basehist
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.classichist module
------------------------
-
-.. automodule:: hist.classichist
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.hist module
-----------------
-
-.. automodule:: hist.hist
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.intervals module
----------------------
-
-.. automodule:: hist.intervals
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.namedhist module
----------------------
-
-.. automodule:: hist.namedhist
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.numpy module
------------------
-
-.. automodule:: hist.numpy
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.stack module
--------------------
-
-.. automodule:: hist.stack
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.storage module
--------------------
-
-.. automodule:: hist.storage
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.tag module
----------------
-
-.. automodule:: hist.tag
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-hist.version module
--------------------
-
-.. automodule:: hist.version
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: hist
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   hist.accumulators
+   hist.axestuple
+   hist.basehist
+   hist.classichist
+   hist.hist
+   hist.intervals
+   hist.namedhist
+   hist.numpy
+   hist.stack
+   hist.storage
+   hist.tag
+   hist.version

--- a/docs/reference/hist.stack.rst
+++ b/docs/reference/hist.stack.rst
@@ -1,0 +1,7 @@
+hist.stack module
+=================
+
+.. automodule:: hist.stack
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.storage.rst
+++ b/docs/reference/hist.storage.rst
@@ -1,0 +1,7 @@
+hist.storage module
+===================
+
+.. automodule:: hist.storage
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.tag.rst
+++ b/docs/reference/hist.tag.rst
@@ -1,0 +1,7 @@
+hist.tag module
+===============
+
+.. automodule:: hist.tag
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/hist.version.rst
+++ b/docs/reference/hist.version.rst
@@ -1,0 +1,7 @@
+hist.version module
+===================
+
+.. automodule:: hist.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/modules.rst
+++ b/docs/reference/modules.rst
@@ -2,6 +2,6 @@ hist
 ====
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 5
 
    hist


### PR DESCRIPTION
I was going through the documentation of `hist` to get some inspiration for `vector`, and I found some minor problems with the structure of the API docs. Some of the docs are hidden deep under the web pages, and some of them are not listed in the index. Here is what the changes look like -

### Before
![image](https://user-images.githubusercontent.com/74055102/174132132-d150b894-e05b-4fd2-971e-baf112d6b06d.png)

### After
![image](https://user-images.githubusercontent.com/74055102/174132187-83722e32-9f27-4192-8948-cde6340d254d.png)

### Before
![image](https://user-images.githubusercontent.com/74055102/174132392-65f5a49b-a188-495c-9152-1c0336fdb59f.png)

### After
![image](https://user-images.githubusercontent.com/74055102/174132357-152510b1-378c-42c8-b862-ab7a5020cdc4.png)

### Before
![image](https://user-images.githubusercontent.com/74055102/174132776-90e10744-249e-4bf5-84bc-825b4be59470.png)

### After
![image](https://user-images.githubusercontent.com/74055102/174132702-0e905bf4-ac38-4401-a997-76800b48a4f5.png)
