### PR TITLE
docs: Add CITATION.cff Citation File Format file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+title: "hist: v2.6.1"
+abstract: "Hist is an analyst-friendly front-end for boost-histogram, designed for Python 3.7+."
+authors:
+- family-names: "Schreiner"
+  given-names: "Henry"
+  orcid: "https://orcid.org/0000-0002-7833-783X"
+  affiliation: "Princeton University"
+- family-names: "Liu"
+  given-names: "Shuo"
+  affiliation: "Columbia University in the City of New York"
+- family-names: "Goel"
+  given-names: "Aman"
+  orcid: "https://orcid.org/0000-0003-3567-2096"
+  affiliation: "University of Delhi"
+version: 2.6.1
+doi: 10.5281/zenodo.4057112
+repository-code: "https://github.com/scikit-hep/hist/releases/tag/v2.6.1"
+url: "https://hist.readthedocs.io/"
+keywords:
+  - python
+  - histogram
+  - scikit-hep
+license: "BSD-3-Clause"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "Please cite the following works when using this software."
 type: software
-title: "hist: v2.6.1"
+title: "hist"
 abstract: "Hist is an analyst-friendly front-end for boost-histogram, designed for Python 3.7+."
 authors:
 - family-names: "Schreiner"
@@ -15,9 +15,8 @@ authors:
   given-names: "Aman"
   orcid: "https://orcid.org/0000-0003-3567-2096"
   affiliation: "University of Delhi"
-version: 2.6.1
 doi: 10.5281/zenodo.4057112
-repository-code: "https://github.com/scikit-hep/hist/releases/tag/v2.6.1"
+repository-code: "https://github.com/scikit-hep/hist"
 url: "https://hist.readthedocs.io/"
 keywords:
   - python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE pyproject.toml README.md setup.py setup.cfg
+exclude CITATION.cff
 recursive-include tests *.py *.png
 recursive-include src *.py
 recursive-include src *.pyi


### PR DESCRIPTION
Resolves #413

* Add Citation File Format file to repo to get repository cite button on GitHub and citation support on Zenodo.
   - c.f. https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files

For additional context and examples c.f. https://github.com/scikit-hep/pyhf/pull/1551

The schema used is validated by [`cffconvert`](https://pypi.org/project/cffconvert/)

```console
$ pipx install cffconvert
$ cffconvert --validate --infile CITATION.cff 
Citation metadata are valid according to schema version 1.2.0.
```