### PR TITLE
chore: cleanup dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "actions/*"


### PR DESCRIPTION
Remove obsolete configuration from `dependabot.yml`