### PR TITLE
chore: remove redundant MANIFEST related metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       with:
         python-version: "3.x"
     - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args: --hook-stage manual check-manifest
     - name: PyLint
       run: |
         echo "::add-matcher::$GITHUB_WORKSPACE/.github/matchers/pylint.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,25 +118,6 @@ pyupgrade = 1
 [tool.isort]
 profile = "black"
 
-[tool.check-manifest]
-ignore = [
-    ".pre-commit-config.yaml",
-    ".readthedocs.yml",
-    "examples/**",
-    "notebooks/**",
-    "docs/**",
-    "CONTRIBUTING.md",
-    "*.html",
-    "*.in",
-    "*.json",
-    "*.yml",
-    "src/hist/version.py",
-    "tests/.pytest_cache/**",
-    ".all-contributorsrc",
-    "noxfile.py",
-]
-
-
 [tool.mypy]
 warn_unused_configs = true
 files = "src"


### PR DESCRIPTION
I was adding `Pylint` to `vector` and discovered these redundant lines here 😅 