### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: "1.14.0"
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==23.1.0]
+    additional_dependencies: [black==23.3.0]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
@@ -39,7 +39,7 @@ repos:
   rev: 1.7.0
   hooks:
   - id: nbqa-ruff
-    additional_dependencies: [ruff==0.0.253]
+    additional_dependencies: [ruff==0.0.255]
     args: ["--extend-ignore=B008,T20,I002,E402", "--fix", "--show-fixes"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
@@ -49,12 +49,6 @@ repos:
     files: ^src
     args: []
     additional_dependencies: ["numpy~=1.24.0", "matplotlib>=3.4", "boost-histogram~=1.3.1", "uhi~=0.3.1", "pandas-stubs>=2.0.1.230501"]
-
-- repo: https://github.com/mgedmin/check-manifest
-  rev: "0.49"
-  hooks:
-  - id: check-manifest
-    stages: [manual]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ select = [
   "YTT",         # flake8-2020
 ]
 extend-ignore = ["PLR", "E501", "PT011", "PT013", "PT004", "B017"]
-target-version = "py37"
 typing-modules = ["hist._compat.typing"]
 src = ["src"]
 unfixable = ["T20", "F841"]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos