### PR TITLE
chore: prepare for 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   FORCE_COLOR: 3
 
 concurrency:
-  group: ${ github.workflow }-${ github.head_ref }
+  group: ${ github.workflow }-${ github.ref }
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Hist currently provides everything boost-histogram provides, and the following e
   - `.density()` computes the density as an array.
   - `.profile(remove_ax)` can convert a ND COUNT histogram into a (N-1)D MEAN histogram.
   - `.sort(axis)` supports sorting a histogram by a categorical axis. Optionally takes a function to sort by.
+  - `.fill_flattened(...)` will flatten and fill, including support for AwkwardArray.
+  - `.integrate(...)`, which takes the opposite arguments as `.project`.
 
 - Hist implements UHI+; an extension to the UHI (Unified Histogram Indexing) system designed for import-free interactivity:
   - Uses `j` suffix to switch to data coordinates in access or slices.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,25 @@
 # Changelog
 
+
+## Version 2.7.0
+
+Features:
+
+* Add a function to integrate axes
+  [#505](https://github.com/scikit-hep/hist/pull/505)
+* Add `fill_flattened` support
+  [#474](https://github.com/scikit-hep/hist/pull/474)
+
+Various other items:
+
+* Move linting to using Ruff
+  [#475](https://github.com/scikit-hep/hist/pull/475)
+* `Self` & `_compat`
+  [#479](https://github.com/scikit-hep/hist/pull/479)
+* Rework and rerun docs API
+  [#481](https://github.com/scikit-hep/hist/pull/481)
+
+
 ## Version 2.6.3
 
 * Experimental dask support


### PR DESCRIPTION
Having `fill_flattened` would be nice. Also `integrate`.
