### PR TITLE
fix: plot extra split into [fit]

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Python 3.7+ (3.6 users get version 2.4). See [what's new](https://hist.readthedo
 You can install this library from [PyPI](https://pypi.org/project/hist/) with pip:
 
 ```bash
-python3 -m pip install "hist[plot]"
+python3 -m pip install "hist[plot,fit]"
 ```
 
-If you do not need the plotting features, you can skip the `[plot]` extra.
+If you do not need the plotting features, you can skip the `[plot]` and/or
+`[fit]` extras. `[fit]` is not currently supported in WebAssembly.
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ mpl = [
 plot = [
     "matplotlib >=3.0",
     "mplhep >=0.2.16",
+]
+fit = [
     "scipy >=1.4",
     "iminuit >=2",
 ]

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -32,7 +32,7 @@ __all__ = (
     "plot_stack",
 )
 
-_PLT_MISSING_MSG = "Hist plotting with fitting requires scipy and iminuit. Please install hist[plot] or manually install dependencies."
+_PLT_MISSING_MSG = "Hist plotting with fitting requires scipy and iminuit. Please install hist[plot,fit] or manually install dependencies."
 
 
 class FitResultArtists(NamedTuple):


### PR DESCRIPTION
Adding `iminuit` breaks WebAssembly until we get it added to Pyodide. Let's split the extras.
