### PR TITLE
fix: support boost-histogram 1.4+ (+ nox)

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -108,3 +108,28 @@ def build(session):
 
     session.install("build")
     session.run("python", "-m", "build")
+
+
+@nox.session()
+def boost(session):
+    """
+    Build against latest boost-histogram.
+    """
+
+    tmpdir = session.create_tmp()
+    session.chdir(tmpdir)
+    # Support running with -r/-R
+    if not Path("boost-histogram").is_dir():
+        session.run(
+            "git",
+            "clone",
+            "--recursive",
+            "https://github.com/scikit-hep/boost-histogram",
+            external=True,
+        )
+        session.chdir("boost-histogram")
+        session.install(".")
+    session.chdir(DIR)
+    session.install("-e.[test,plot]")
+    session.run("pip", "list")
+    session.run("pytest", *session.posargs)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -54,12 +54,12 @@ def test_init_and_fill(unnamed_hist):
 
     assert unnamed_hist(
         axis.Integer(-3, 3, name="x"), axis.Integer(-3, 3, name="y")
-    ).fill(np.random.randn(10), np.random.randn(10))
+    ).fill(np.random.randint(-3, 3, 10), np.random.randint(-3, 3, 10))
 
     assert unnamed_hist(
         axis.IntCategory(range(-3, 3), name="x"),
         axis.IntCategory(range(-3, 3), name="y"),
-    ).fill(np.random.randn(10), np.random.randn(10))
+    ).fill(np.random.randint(-3, 3, 10), np.random.randint(-3, 3, 10))
 
     assert unnamed_hist(
         axis.StrCategory(["F", "T"], name="x"), axis.StrCategory("FT", name="y")
@@ -181,8 +181,8 @@ def test_general_fill():
         axis.Integer(0, 10, name="y"),
         axis.Integer(0, 2, name="z"),
     ).fill(
-        [3.5, 3.5, 3.5, 4.5, 5.5, 5.5, 5.5],
-        [3.5, 3.5, 4.5, 4.5, 4.5, 4.5, 4.5],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 4, 4, 4, 4, 4],
         [0, 0, 1, 1, 1, 1, 1],
     )
 
@@ -202,8 +202,8 @@ def test_general_fill():
         axis.IntCategory(range(10), name="y"),
         axis.IntCategory(range(2), name="z"),
     ).fill(
-        x=[3.5, 3.5, 3.5, 4.5, 5.5, 5.5, 5.5],
-        y=[3.5, 3.5, 4.5, 4.5, 4.5, 4.5, 4.5],
+        x=[3, 3, 3, 4, 5, 5, 5],
+        y=[3, 3, 4, 4, 4, 4, 4],
         z=[0, 0, 1, 1, 1, 1, 1],
     )
 
@@ -248,13 +248,13 @@ def test_general_fill():
     ).fill(x=np.random.randn(10), y=np.random.randn(10))
 
     assert Hist(axis.Integer(-3, 3, name="x"), axis.Integer(-3, 3, name="y")).fill(
-        x=np.random.randn(10), y=np.random.randn(10)
+        x=np.random.randint(-3, 3, 10), y=np.random.randint(-3, 3, 10)
     )
 
     assert Hist(
         axis.IntCategory(range(-3, 3), name="x"),
         axis.IntCategory(range(-3, 3), name="y"),
-    ).fill(x=np.random.randn(10), y=np.random.randn(10))
+    ).fill(x=np.random.randint(-3, 3, 10), y=np.random.randint(-3, 3, 10))
 
     assert Hist(
         axis.StrCategory(["F", "T"], name="x"), axis.StrCategory("FT", name="y")
@@ -290,7 +290,7 @@ def test_general_access():
         np.random.uniform(size=1000),
         ["hi"] * 800 + ["hello"] * 200,
         [True] * 600 + [False] * 400,
-        np.ones(1000),
+        np.ones(1000, dtype=int),
     )
 
     assert h[0j, -0j + 2, "hi", True, 1]
@@ -373,7 +373,7 @@ def test_general_index_access():
         np.ones(10) * 2,
         ["hi"] * 8 + ["hello"] * 2,
         [True] * 6 + [False] * 4,
-        np.ones(10),
+        np.ones(10, dtype=int),
     )
 
     assert h[1j, 2j, "hi", True, 1] == 6

--- a/tests/test_mock_plot.py
+++ b/tests/test_mock_plot.py
@@ -38,6 +38,6 @@ def test_integer_plot():
         .Reg(10, 0, 10, name="good", label="y-axis")
         .Int64()
     )
-    testInt.fill(nice=np.random.normal(5, 1, 10), good=np.random.normal(5, 1, 10))
+    testInt.fill(nice=np.random.randint(1, 10, 10), good=np.random.normal(5, 1, 10))
 
     assert testInt.plot() == "called plot2d"

--- a/tests/test_named.py
+++ b/tests/test_named.py
@@ -46,13 +46,13 @@ def test_named_init():
     ).fill(x=np.random.randn(10), y=np.random.randn(10))
 
     assert NamedHist(axis.Integer(-3, 3, name="x"), axis.Integer(-3, 3, name="y")).fill(
-        x=np.random.randn(10), y=np.random.randn(10)
+        x=np.random.randint(-3, 3, 10), y=np.random.randint(-3, 3, 10)
     )
 
     assert NamedHist(
         axis.IntCategory(range(-3, 3), name="x"),
         axis.IntCategory(range(-3, 3), name="y"),
-    ).fill(x=np.random.randn(10), y=np.random.randn(10))
+    ).fill(x=np.random.randint(-3, 3, 10), y=np.random.randint(-3, 3, 10))
 
     assert NamedHist(
         axis.StrCategory(["F", "T"], name="x"), axis.StrCategory("FT", name="y")
@@ -218,8 +218,8 @@ def test_named_fill():
         axis.Integer(0, 10, name="y"),
         axis.Integer(0, 2, name="z"),
     ).fill(
-        x=[3.5, 3.5, 3.5, 4.5, 5.5, 5.5, 5.5],
-        y=[3.5, 3.5, 4.5, 4.5, 4.5, 4.5, 4.5],
+        x=[3, 3, 3, 4, 5, 5, 5],
+        y=[3, 3, 4, 4, 4, 4, 4],
         z=[0, 0, 1, 1, 1, 1, 1],
     )
 
@@ -251,8 +251,8 @@ def test_named_fill():
         axis.IntCategory(range(10), name="y"),
         axis.IntCategory(range(2), name="z"),
     ).fill(
-        x=[3.5, 3.5, 3.5, 4.5, 5.5, 5.5, 5.5],
-        y=[3.5, 3.5, 4.5, 4.5, 4.5, 4.5, 4.5],
+        x=[3, 3, 3, 4, 5, 5, 5],
+        y=[3, 3, 4, 4, 4, 4, 4],
         z=[0, 0, 1, 1, 1, 1, 1],
     )
 
@@ -389,7 +389,7 @@ def test_named_access():
         Unif=np.random.uniform(size=1000),
         Greet=["hi"] * 800 + ["hello"] * 200,
         Yes=[True] * 600 + [False] * 400,
-        Int=np.ones(1000),
+        Int=np.ones(1000, dtype=int),
     )
 
     assert h[0j, -0j + 2, "hi", True, 1]
@@ -562,7 +562,7 @@ def test_named_index_access():
         Twos=np.ones(10) * 2,
         Greet=["hi"] * 8 + ["hello"] * 2,
         Yes=[True] * 6 + [False] * 4,
-        Int=np.ones(10),
+        Int=np.ones(10, dtype=int),
     )
 
     assert h[1j, 2j, "hi", True, 1] == 6


### PR DESCRIPTION
It's now easy to test against the latest development version of boost-histogram with `nox -Rs boost`. Used to clean up reset of sloppy integer tests.
