### PR TITLE
fix: hist.dask.new to match top-level package

### DIFF
--- a/src/hist/dask/__init__.py
+++ b/src/hist/dask/__init__.py
@@ -13,4 +13,6 @@ if not importlib.util.find_spec("dask_histogram"):
 from .hist import Hist
 from .namedhist import NamedHist
 
-__all__ = ["Hist", "NamedHist"]
+new = Hist.new
+
+__all__ = ["Hist", "NamedHist", "new"]


### PR DESCRIPTION
This makes it so that `hist.dask` has the equivalent of `hist.new`, which is was missing.