### PR TITLE
fix: test needs mplhep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dask = [
 test = [
     "pytest >=6",
     "pytest-mpl >=0.12",
+    "hist[plot]",
 ]
 dev = [
     "hist[mpl,fit,test,dask]",


### PR DESCRIPTION
```
FAILED tests/test_plot.py::test_general_plot1d - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_general_plot2d - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_general_plot2d_full - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_general_plot - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_general_plot_pull - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_named_plot1d - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_named_plot2d - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_named_plot2d_full - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_named_plot - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_named_plot_pull - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_ratiolike_str_alias[True-normal] - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_ratiolike_str_alias[True-gauss] - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_ratiolike_str_alias[True-gaus] - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_ratiolike_str_alias[False-normal] - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_ratiolike_str_alias[False-gauss] - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_ratiolike_str_alias[False-gaus] - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_image_plot_pull - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_image_plot_ratio_hist - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_image_plot_ratio_callable - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_plot.py::test_plot1d_auto_handling - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_stacks.py::test_stack_plot_construct - ModuleNotFoundError: No module named 'mplhep'
FAILED tests/test_stacks.py::test_stack_plot - ModuleNotFoundError: No module named 'mplhep'
========================== 22 failed, 149 passed, 1 skipped in 5.68s ==========================
```