### PR TITLE
Fix name attribute in Hist constructor

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -93,8 +93,8 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
         """
         self._hist: Any = None
         self.axes: NamedAxesTuple
-        self.name = name
-        self.label = label
+
+        args: tuple[AxisTypes, ...]
 
         args: tuple[AxisTypes, ...]
 
@@ -121,6 +121,8 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
 
         super().__init__(*args, storage=storage, metadata=metadata)  # type: ignore[call-overload]
 
+        self.name = name
+        self.label = label
         disallowed_names = {"weight", "sample", "threads"}
         for ax in self.axes:
             if ax.name in disallowed_names:

--- a/test_hist_name.py
+++ b/test_hist_name.py
@@ -1,0 +1,12 @@
+import hist
+import boost_histogram as bh
+
+# Test case 1: Creating from axes with name (should work)
+a = hist.axis.Regular(10, 0, 10, name="r")
+h1 = hist.Hist(a, name="hello")
+print("Test 1 - Name from axes:", h1.name)  # Should print "hello"
+
+# Test case 2: Creating from bh.Histogram with name (was broken)
+bh_hist = bh.Histogram(a)
+h2 = hist.Hist(bh_hist, name="world")
+print("Test 2 - Name from bh.Histogram:", h2.name)  # Should print "world"


### PR DESCRIPTION
Fixes #581 <!-- Needed for GitHub to link the issue to the PR -->

## Fix name attribute in Hist constructor
This commit fixes an issue where the `name` attribute would not be properly set when initializing a `Hist` from a `bh.Histogram` object. The fix moves the name/label assignment after the `super().__init__` call to ensure proper initialization of the underlying histogram first. A test case was added to verify both direct axis construction and boost-histogram construction methods work correctly with the `name` parameter.

The bug was caused by attempting to set `self.name` before the parent class was fully initialized, which meant the attribute could be lost in some cases. Now name/label attributes are reliably set for all construction methods.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci8yZWQwNDgyNjcyNTg1YWMxNWM3NjFhMTI0NDI5NzhlNS9yYXcvc3dlYmVuY2hfc2Npa2l0LWhlcF9faGlzdC01ODEuanNvbg) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=&rb85bea8de07843f9835f9d001f689f4c=&r034de175aef248b29aaf36f2a5e92912=&r9e0cc5d7ff8b484e81eb97531d4cefd7=) 📬.