### PR TITLE
fix: `fill_flattened` broadcasting of non user kwargs

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -314,7 +314,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
                 )
         # Multiple args: broadcast and flatten!
         else:
-            inputs = (*args, *kwargs.values(), *non_user_kwargs)
+            inputs = (*args, *kwargs.values(), *non_user_kwargs.values())
             broadcast = interop.broadcast_and_flatten(inputs)
             user_args_broadcast = broadcast[: len(args)]
             user_kwargs_broadcast = dict(

--- a/src/hist/namedhist.py
+++ b/src/hist/namedhist.py
@@ -106,7 +106,7 @@ class NamedHist(BaseHist, family=hist):
             )
         # Multiple args: broadcast and flatten!
         else:
-            inputs = (*kwargs.values(), *non_user_kwargs)
+            inputs = (*kwargs.values(), *non_user_kwargs.values())
             broadcast = interop.broadcast_and_flatten(inputs)
             user_kwargs_broadcast = dict(zip(kwargs, broadcast[: len(kwargs)]))
             non_user_kwargs_broadcast = dict(


### PR DESCRIPTION
When using`fill_flattened` with multiple args and either the `weight` or `sample` kwargs, it tries to broadcast the keys of `non_user_kwargs` instead of the values, leading to kwargs trying to fill the histogram with the stringified kwarg name instead of its value (such as the `sample` kwarg attempting to fill the array with `["sample", "sample", "sample", "sample"]`). This PR changes that behavior to insert the values instead.