### PR TITLE
[DOCS] Fix broken links to boost-histogram docs

### DIFF
--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -17,4 +17,4 @@ You can also install it with Conda from conda-forge.
 
 
 Supported platforms are identical to
-`boost-histogram <https://boost-histogram.readthedocs.io/en/latest/usage/installation.html>`_.
+`boost-histogram <https://boost-histogram.readthedocs.io/en/latest/user-guide/installation.html>`_.

--- a/docs/user-guide/notebooks/Transform.ipynb
+++ b/docs/user-guide/notebooks/Transform.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## Transform Types\n",
     "\n",
-    "Here we show some basic usage of transforms in histogramming with pure Python. For more customized usage, you can refer the part in that of [boost-histogram](https://boost-histogram.readthedocs.io/en/latest/usage/transforms.html)."
+    "Here we show some basic usage of transforms in histogramming with pure Python. For more customized usage, you can refer the part in that of [boost-histogram](https://boost-histogram.readthedocs.io/en/latest/user-guide/transforms.html)."
    ]
   },
   {


### PR DESCRIPTION
Hello :) This PR fixes two broken links in the docs that point to [boost-histogram](https://boost-histogram.readthedocs.io/en/latest/)'s docs, one in [`user-guide/notebooks/Transform`](https://hist.readthedocs.io/en/latest/user-guide/notebooks/Transform.html) and the other one in [`user-guide/installation`](https://hist.readthedocs.io/en/latest/user-guide/installation.html).