### PR TITLE
ci: add pass job for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,14 @@ jobs:
 
     - name: Test plotting too
       run: python -m pytest --mpl
+
+  pass:
+    if: always()
+    needs: [pylint, checks]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Add pass job, makes it possible to add and remove jobs without failing PRs.
