### PR TITLE
Improve error message for invalid weighted fill

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -305,7 +305,7 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
 
         data = (data_dict[i] for i in range(len(args), self.ndim))
 
-        # ----START. Clearer error for invalid weighted fill :
+        # Quick check for a common mistake with a weighted fill
         if (
             weight is not None
             and args
@@ -316,7 +316,6 @@ class BaseHist(bh.Histogram, metaclass=MetaConstructor, family=hist):
             raise ValueError(
                 "Weight array must match the length of the input data for a given data"
             )
-        # ----END.
 
         return super().fill(*args, *data, weight=weight, sample=sample, threads=threads)
 


### PR DESCRIPTION
### What changed

Adds an early, clearer `ValueError` when `weight` is provided with a length
that does not match the input data passed to `Hist.fill`.

Previously, this case raised a confusing backend error originating from
`boost-histogram`. This change surfaces a more actionable message at the
`hist` API level.

### Scope

- No behavior change for valid inputs
- Only improves error reporting for already-invalid usage
