### PR TITLE
feat: add chunked histograms

### DIFF
--- a/src/hist/chunked.py
+++ b/src/hist/chunked.py
@@ -1,0 +1,683 @@
+from __future__ import annotations
+
+import fnmatch
+import itertools
+import typing as tp
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import boost_histogram as bh
+import numpy as np
+
+import hist
+
+__all__ = (
+    "ChunkKey",
+    "ChunkScalar",
+    "ChunkedHist",
+    "normalize_chunk_selection",
+)
+
+
+ChunkScalar = str | int
+ChunkKey = tuple[ChunkScalar, ...]
+
+
+def _validate_supported_axis(axis: tp.Any) -> None:
+    if (
+        isinstance(axis, bh.axis.Regular)
+        and getattr(axis, "transform", None) is not None
+    ):
+        raise ValueError("ChunkedHist does not support transformed Regular axes yet")
+
+
+def _validate_supported_storage(storage: tp.Any) -> None:
+    storage_type = type(storage)
+    if storage_type in {bh.storage.Mean, bh.storage.WeightedMean}:
+        raise ValueError(
+            f"ChunkedHist does not support {storage_type.__name__} storage yet"
+        )
+
+
+def _validate_dense_view(
+    view: tp.Any,
+    *,
+    shape: tuple[int, ...],
+    dtype: np.dtype[tp.Any],
+) -> np.ndarray:
+    array = np.asarray(view)
+    if array.shape != shape:
+        raise ValueError(
+            f"dense view shape mismatch: expected {shape}, got {array.shape}"
+        )
+    if array.dtype != dtype:
+        raise ValueError(
+            f"dense view dtype mismatch: expected {dtype}, got {array.dtype}"
+        )
+    return array
+
+
+def _accumulate_dense_view(target: np.ndarray, source: np.ndarray) -> None:
+    if target.dtype.fields is None:
+        target[...] += source
+        return
+    for field_name in target.dtype.names or ():
+        _accumulate_dense_view(target[field_name], source[field_name])
+
+
+def _zero_dense_view(view: np.ndarray) -> None:
+    if view.dtype.fields is None:
+        view.fill(0)
+        return
+    for field_name in view.dtype.names or ():
+        _zero_dense_view(view[field_name])
+
+
+def _normalize_chunk_scalar(value: tp.Any) -> ChunkScalar:
+    if isinstance(value, np.generic):
+        value = value.item()
+    if not isinstance(value, str | int):
+        raise TypeError(
+            f"chunk axis values must normalize to str or int, got {type(value)=}"
+        )
+    return value
+
+
+def _is_scalar_like(value: tp.Any) -> bool:
+    if isinstance(value, str | bytes):
+        return True
+    if np.isscalar(value):
+        return True
+    return bool(isinstance(value, np.ndarray) and value.ndim == 0)
+
+
+def normalize_chunk_selection(
+    selection: Mapping[str, ChunkScalar | tp.Iterable[ChunkScalar]],
+    *,
+    axis_names: Iterable[str],
+    chunk_axis_names: Iterable[str],
+) -> dict[str, tuple[ChunkScalar, ...]]:
+    known_axes = set(axis_names)
+    known_chunk_axes = set(chunk_axis_names)
+    normalized: dict[str, tuple[ChunkScalar, ...]] = {}
+
+    for axis_name, raw_value in selection.items():
+        if axis_name not in known_axes:
+            raise KeyError(f"unknown axis in slice: {axis_name!r}")
+        if axis_name not in known_chunk_axes:
+            raise ValueError(
+                f"slicing only supports chunk axes; {axis_name!r} is dense"
+            )
+        values = (raw_value,) if isinstance(raw_value, str | int) else tuple(raw_value)
+        if not values:
+            raise ValueError(f"slice for axis {axis_name!r} must be non-empty")
+        normalized[axis_name] = tuple(
+            _normalize_chunk_scalar(value) for value in values
+        )
+
+    return normalized
+
+
+@dataclass(slots=True)
+class ChunkAxisSpec:
+    index: int
+    name: str
+    axis_type: type[tp.Any]
+    label: str
+    metadata: tp.Any
+    growth: bool
+    flow: bool
+    known_keys: list[ChunkScalar]
+
+
+@dataclass(slots=True, init=False)
+class ChunkedHist:
+    chunk_axes: list[ChunkAxisSpec]
+    axes: tuple[tp.Any, ...]
+    storage_type: type[tp.Any]
+    name: str
+    label: str
+    _dense_view_shape: tuple[int, ...] = field(init=False)
+    _dense_view_dtype: np.dtype[tp.Any] = field(init=False)
+    _dense_view_nbytes: int = field(init=False)
+    _chunk_axis_names: tuple[str, ...] = field(init=False)
+    _scratch_dense_hist: hist.Hist[Any] = field(init=False)
+    _chunks: dict[ChunkKey, np.ndarray] = field(default_factory=dict)
+
+    def __init__(
+        self,
+        *axes: tp.Any,
+        storage: tp.Any | None = None,
+        name: str = "",
+        label: str = "",
+    ) -> None:
+        """Initialize a chunked histogram.
+
+        Args:
+            *axes: Histogram axes. Named categorical axes become chunk axes.
+            storage: Boost-histogram storage instance. Defaults to ``Double()``.
+            name: Histogram name.
+            label: Histogram label.
+
+        Example:
+            >>> h = ChunkedHist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory([], growth=True, name="cat"),
+            ... )
+            >>> h.fill(x=[0.2, 0.4], cat="a")
+        """
+        if not axes:
+            raise ValueError("ChunkedHist requires at least one axis")
+        if not all(getattr(axis, "name", None) for axis in axes):
+            raise ValueError("all axes must have names")
+        if storage is None:
+            storage = bh.storage.Double()
+        for axis in axes:
+            _validate_supported_axis(axis)
+        _validate_supported_storage(storage)
+
+        self.axes = tuple(axes)
+        self.storage_type = type(storage)
+        self.name = name
+        self.label = label
+        self._chunks = {}
+
+        self.chunk_axes = []
+        dense_axes: list[tp.Any] = []
+        for index, axis in enumerate(self.axes):
+            if isinstance(axis, bh.axis.IntCategory | bh.axis.StrCategory):
+                self.chunk_axes.append(
+                    ChunkAxisSpec(
+                        index=index,
+                        name=axis.name,
+                        axis_type=type(axis),
+                        label=axis.label,
+                        metadata=axis.metadata,
+                        growth=axis.traits.growth,
+                        flow=axis.traits.overflow or axis.traits.underflow,
+                        known_keys=[_normalize_chunk_scalar(key) for key in axis],
+                    )
+                )
+            else:
+                dense_axes.append(axis)
+
+        self._chunk_axis_names = tuple(spec.name for spec in self.chunk_axes)
+
+        self._scratch_dense_hist = hist.Hist(
+            *dense_axes,
+            storage=self.storage_type(),
+            name=self.name,
+            label=self.label,
+        )
+        dense_view = self._scratch_dense_hist.view(flow=True)
+        self._dense_view_shape = dense_view.shape
+        self._dense_view_dtype = dense_view.dtype
+        self._dense_view_nbytes = dense_view.nbytes
+
+    @classmethod
+    def from_hist(
+        cls,
+        source: hist.Hist[Any],
+    ) -> ChunkedHist:
+        """Build a ``ChunkedHist`` from an existing ``hist.Hist``.
+
+        Args:
+            source: Source histogram to copy into chunked storage.
+
+        Returns:
+            A new ``ChunkedHist`` containing the same bin contents.
+
+        Example:
+            >>> source = hist.Hist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory(["a"], growth=True, name="cat"),
+            ... )
+            >>> source.fill(x=[0.2, 0.4], cat=["a", "a"])
+            >>> chunked = ChunkedHist.from_hist(source)
+        """
+        chunked = cls(
+            *source.axes,
+            storage=source.storage_type(),
+            name=source.name or "",
+            label=source.label or "",
+        )
+        source_view = source.view(flow=True)
+        if not chunked.chunk_axes:
+            chunked._save_chunk_view((), np.ascontiguousarray(source_view))
+            return chunked
+
+        if not any(spec.known_keys for spec in chunked.chunk_axes):
+            return chunked
+
+        for key_indices in itertools.product(
+            *(range(len(spec.known_keys)) for spec in chunked.chunk_axes)
+        ):
+            selector: list[tp.Any] = [slice(None)] * source_view.ndim
+            key_values: list[ChunkScalar] = []
+            for spec, key_index in zip(chunked.chunk_axes, key_indices, strict=True):
+                selector[spec.index] = key_index
+                key_values.append(spec.known_keys[key_index])
+            chunked._save_chunk_view(
+                tuple(key_values),
+                np.ascontiguousarray(source_view[tuple(selector)]),
+            )
+
+        return chunked
+
+    @property
+    def chunk_axis_names(self) -> tuple[str, ...]:
+        return self._chunk_axis_names
+
+    @property
+    def dense_view_shape(self) -> tuple[int, ...]:
+        return self._dense_view_shape
+
+    @property
+    def dense_view_dtype(self) -> np.dtype[tp.Any]:
+        return self._dense_view_dtype
+
+    @property
+    def dense_axes(self) -> tuple[tp.Any, ...]:
+        return tuple(self._scratch_dense_hist.axes)
+
+    def _save_chunk_view(self, key: ChunkKey, chunk_view: np.ndarray) -> None:
+        array = _validate_dense_view(
+            np.ascontiguousarray(chunk_view),
+            shape=self.dense_view_shape,
+            dtype=self.dense_view_dtype,
+        )
+        if not array.flags.writeable:
+            array = array.copy()
+        self._chunks[key] = array
+
+    def _remember_chunk_key(self, key: ChunkKey) -> None:
+        for spec, key_part in zip(self.chunk_axes, key, strict=True):
+            if key_part not in spec.known_keys:
+                spec.known_keys.append(key_part)
+
+    def split_fill_kwargs(
+        self, kwargs: Mapping[str, tp.Any]
+    ) -> tuple[ChunkKey, dict[str, tp.Any]]:
+        missing = [name for name in self.chunk_axis_names if name not in kwargs]
+        if missing:
+            raise ValueError(f"missing chunk axes in fill kwargs: {missing!r}")
+
+        chunk_key: list[ChunkScalar] = []
+        for name in self.chunk_axis_names:
+            value = kwargs[name]
+            if not _is_scalar_like(value):
+                raise ValueError(
+                    f"categorical chunk axis {name!r} only accepts scalar int/str values"
+                )
+            chunk_key.append(_normalize_chunk_scalar(value))
+
+        return tuple(chunk_key), {
+            name: value
+            for name, value in kwargs.items()
+            if name not in self.chunk_axis_names
+        }
+
+    def add_dense_view(self, key: ChunkKey, dense_view: np.ndarray) -> None:
+        dense_view = _validate_dense_view(
+            dense_view,
+            shape=self.dense_view_shape,
+            dtype=self.dense_view_dtype,
+        )
+        chunk_view = self._chunks.get(key)
+        if chunk_view is None:
+            self._save_chunk_view(key, dense_view)
+            self._remember_chunk_key(key)
+            return
+        _accumulate_dense_view(chunk_view, dense_view)
+
+    def fill(self, **kwargs: tp.Any) -> None:
+        """Fill one chunk of the histogram.
+
+        Args:
+            **kwargs: Named axis values and optional storage arguments such as
+                ``weight`` or ``sample``. Chunk axes must receive scalar values.
+
+        Example:
+            >>> h = ChunkedHist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory([], growth=True, name="cat"),
+            ... )
+            >>> h.fill(x=[0.2, 0.4], cat="a")
+        """
+        chunk_key, dense_kwargs = self.split_fill_kwargs(kwargs)
+        dense_hist = self._scratch_dense_hist
+        dense_view = dense_hist.view(flow=True)
+        try:
+            chunk_view = self._chunks.get(chunk_key)
+            if chunk_view is not None:
+                dense_view[...] = chunk_view
+            dense_hist.fill(**dense_kwargs)
+            existing = self._chunks.get(chunk_key)
+            if existing is None:
+                self._save_chunk_view(chunk_key, dense_view.copy(order="C"))
+                self._remember_chunk_key(chunk_key)
+            else:
+                existing[...] = dense_view
+        finally:
+            _zero_dense_view(dense_view)
+
+    def to_hist(self) -> hist.Hist[Any]:
+        """Materialize the chunked histogram as a ``hist.Hist``.
+
+        Returns:
+            A dense histogram with the currently known categorical keys.
+
+        Example:
+            >>> h = ChunkedHist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory([], growth=True, name="cat"),
+            ... )
+            >>> h.fill(x=[0.2, 0.4], cat="a")
+            >>> dense = h.to_hist()
+        """
+        # TODO: implement native chunked UHI serialization that avoids
+        # expensive materialization to a dense Hist.
+        axes = list(self.axes)
+        keys_by_axis = self._keys_by_axis(self._chunks)
+        for spec in self.chunk_axes:
+            keys = keys_by_axis[spec.name]
+            if issubclass(spec.axis_type, bh.axis.IntCategory):
+                axes[spec.index] = hist.axis.IntCategory(
+                    [tp.cast(int, key) for key in keys],
+                    name=spec.name,
+                    label=spec.label,
+                    metadata=spec.metadata,
+                    growth=spec.growth,
+                    flow=spec.flow,
+                )
+            else:
+                axes[spec.index] = hist.axis.StrCategory(
+                    [tp.cast(str, key) for key in keys],
+                    name=spec.name,
+                    label=spec.label,
+                    metadata=spec.metadata,
+                    growth=spec.growth,
+                    flow=spec.flow,
+                )
+
+        merged = hist.Hist(
+            *axes,
+            storage=self.storage_type(),
+            name=self.name,
+            label=self.label,
+        )
+        merged_view = merged.view(flow=True)
+        axis_key_to_index = [
+            {key: index for index, key in enumerate(keys_by_axis[spec.name])}
+            for spec in self.chunk_axes
+        ]
+
+        for key, chunk_view in self._chunks.items():
+            selector: list[tp.Any] = [slice(None)] * merged_view.ndim
+            for spec, axis_map, key_part in zip(
+                self.chunk_axes, axis_key_to_index, key, strict=True
+            ):
+                selector[spec.index] = axis_map[key_part]
+            merged_view[tuple(selector)] = chunk_view
+
+        return merged
+
+    def empty_like(self) -> ChunkedHist:
+        return ChunkedHist(
+            *self.axes,
+            storage=self.storage_type(),
+            name=self.name,
+            label=self.label,
+        )
+
+    def items(self) -> Iterable[tuple[ChunkKey, np.ndarray]]:
+        for key, chunk_view in self._chunks.items():
+            yield key, np.ascontiguousarray(chunk_view)
+
+    def _keys_by_axis(
+        self,
+        keys: Iterable[ChunkKey],
+    ) -> dict[str, list[ChunkScalar]]:
+        key_lists: dict[str, list[ChunkScalar]] = {
+            spec.name: [] for spec in self.chunk_axes
+        }
+        for key in keys:
+            for spec, key_part in zip(self.chunk_axes, key, strict=True):
+                key_lists[spec.name].append(key_part)
+        return {
+            axis_name: list(dict.fromkeys(values))
+            for axis_name, values in key_lists.items()
+        }
+
+    def _normalize_selection(
+        self,
+        selection: Mapping[str, ChunkScalar | tp.Iterable[ChunkScalar]],
+    ) -> dict[str, tuple[ChunkScalar, ...]]:
+        return normalize_chunk_selection(
+            selection,
+            axis_names=(axis.name for axis in self.axes),
+            chunk_axis_names=self.chunk_axis_names,
+        )
+
+    def _exact_chunk_key(
+        self,
+        normalized: Mapping[str, tuple[ChunkScalar, ...]],
+    ) -> ChunkKey | None:
+        if set(normalized) != set(self.chunk_axis_names):
+            return None
+        if not all(len(values) == 1 for values in normalized.values()):
+            return None
+        return tuple(normalized[axis_name][0] for axis_name in self.chunk_axis_names)
+
+    def exact_chunk_key(
+        self,
+        selection: Mapping[str, ChunkScalar | tp.Iterable[ChunkScalar]],
+    ) -> ChunkKey:
+        normalized = self._normalize_selection(selection)
+        exact_key = self._exact_chunk_key(normalized)
+        if exact_key is None:
+            raise ValueError(
+                "selection must provide exactly one value for each chunk axis"
+            )
+        return exact_key
+
+    def selection_dict(self, key: ChunkKey) -> dict[str, ChunkScalar]:
+        if len(key) != len(self.chunk_axis_names):
+            raise ValueError(
+                f"chunk key must have {len(self.chunk_axis_names)} values, got {len(key)}"
+            )
+        return {
+            axis_name: key[index]
+            for index, axis_name in enumerate(self.chunk_axis_names)
+        }
+
+    def chunk_view(
+        self,
+        selection: Mapping[str, ChunkScalar | tp.Iterable[ChunkScalar]],
+    ) -> np.ndarray:
+        chunk_key = self.exact_chunk_key(selection)
+        exact_selection = self.selection_dict(chunk_key)
+        try:
+            return self._chunks[chunk_key]
+        except KeyError as exc:
+            raise KeyError(f"chunk selection {exact_selection!r} not found") from exc
+
+    def __getitem__(
+        self,
+        selection: Mapping[str, ChunkScalar | tp.Iterable[ChunkScalar]],
+    ) -> ChunkedHist:
+        """Select a subset of chunk keys.
+
+        Args:
+            selection: Mapping of chunk-axis name to one or more allowed values.
+                Supports ``*`` and ``?`` wildcards for ``StrCategory`` chunk axes.
+
+        Returns:
+            A new ``ChunkedHist`` containing only matching chunks.
+
+        Example:
+            >>> h = ChunkedHist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory([], growth=True, name="cat"),
+            ... )
+            >>> h.fill(x=[0.2], cat="a")
+            >>> h.fill(x=[0.4], cat="b")
+            >>> only_a = h[{"cat": "a"}]
+        """
+        raw_normalized = self._normalize_selection(selection)
+
+        # Expand wildcards for StrCategory chunk axes.
+        normalized: dict[str, tuple[ChunkScalar, ...]] = {}
+        chunk_axis_map = {spec.name: spec for spec in self.chunk_axes}
+        for axis_name, values in raw_normalized.items():
+            spec = chunk_axis_map[axis_name]
+            if issubclass(spec.axis_type, bh.axis.StrCategory):
+                expanded: list[ChunkScalar] = []
+                has_wildcard = False
+                for pattern in values:
+                    if isinstance(pattern, str) and any(
+                        special in pattern for special in ("*", "?")
+                    ):
+                        has_wildcard = True
+                        matches = [
+                            k
+                            for k in spec.known_keys
+                            if isinstance(k, str) and fnmatch.fnmatch(k, pattern)
+                        ]
+                        if not matches:
+                            raise ValueError(f"No matches found for {pattern!r}")
+                        expanded.extend(matches)
+                    else:
+                        expanded.append(pattern)
+                if has_wildcard:
+                    normalized[axis_name] = tuple(dict.fromkeys(expanded))
+                else:
+                    normalized[axis_name] = values
+            else:
+                normalized[axis_name] = values
+
+        selected = {name: frozenset(values) for name, values in normalized.items()}
+        matching_keys = [
+            key
+            for key in self._chunks
+            if all(
+                key_part in selected.get(spec.name, {key_part})
+                for spec, key_part in zip(self.chunk_axes, key, strict=True)
+            )
+        ]
+
+        result = self.empty_like()
+        keys_by_axis = self._keys_by_axis(matching_keys)
+        for result_spec in result.chunk_axes:
+            result_spec.known_keys = keys_by_axis[result_spec.name]
+        for key in matching_keys:
+            result._save_chunk_view(key, self._chunks[key].copy(order="C"))
+        return result
+
+    def histogram_bytes(self) -> int:
+        return sum(chunk.nbytes for chunk in self._chunks.values())
+
+    def keys(self) -> Iterable[ChunkKey]:
+        return self._chunks.keys()
+
+    def __iter__(self) -> Iterator[ChunkKey]:
+        return iter(self._chunks.keys())
+
+    def __len__(self) -> int:
+        return len(self._chunks)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._chunks
+
+    def __repr__(self) -> str:
+        axes_repr = ",\n  ".join(
+            # ChunkedHist categorical axes are always growable in practice
+            f"{type(axis).__name__}(..., growth=True, name={axis.name!r})"
+            if isinstance(axis, bh.axis.IntCategory | bh.axis.StrCategory)
+            else repr(axis)
+            for axis in self.axes
+        )
+        total_bytes = self.histogram_bytes()
+        byte_str = (
+            f"{total_bytes} B" if total_bytes < 1024 else f"{total_bytes / 1024:.1f} KB"
+        )
+        return (
+            "ChunkedHist(\n"
+            f"  {axes_repr},\n"
+            f"  storage={self.storage_type()!r})"
+            f" # Chunks: {len(self)}, Bytes: {byte_str}"
+        )
+
+    def __iadd__(self, other: ChunkedHist | hist.Hist[Any]) -> ChunkedHist:
+        """Merge another compatible histogram into this one in place.
+
+        Args:
+            other: Another ``ChunkedHist`` or ``hist.Hist`` with matching schema.
+
+        Returns:
+            This histogram after the merge.
+
+        Example:
+            >>> left = ChunkedHist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory([], growth=True, name="cat"),
+            ... )
+            >>> right = left.empty_like()
+            >>> left.fill(x=[0.2], cat="a")
+            >>> right.fill(x=[0.4], cat="a")
+            >>> left += right
+        """
+        if isinstance(other, hist.Hist):
+            other = ChunkedHist.from_hist(other)
+        if not isinstance(other, ChunkedHist):
+            return NotImplemented
+        if (
+            self.storage_type is not other.storage_type
+            or self.name != other.name
+            or self.label != other.label
+        ):
+            raise ValueError("cannot add incompatible histograms")
+
+        if not all(
+            a == b for a, b in zip(self.dense_axes, other.dense_axes, strict=True)
+        ):
+            raise ValueError("cannot add histograms with incompatible dense axes")
+
+        if not all(
+            a.name == b.name and a.axis_type is b.axis_type
+            for a, b in zip(self.chunk_axes, other.chunk_axes, strict=True)
+        ):
+            raise ValueError("cannot add histograms with incompatible chunk axes")
+        for key, dense_view in other._chunks.items():
+            self.add_dense_view(key, dense_view)
+        return self
+
+    def __add__(self, other: ChunkedHist | hist.Hist[Any]) -> ChunkedHist:
+        """Return a merged copy of two compatible histograms.
+
+        Args:
+            other: Another ``ChunkedHist`` or ``hist.Hist`` with matching schema.
+
+        Returns:
+            A new ``ChunkedHist`` containing the merged contents.
+
+        Example:
+            >>> left = ChunkedHist(
+            ...     hist.axis.Regular(10, 0, 1, name="x"),
+            ...     hist.axis.StrCategory([], growth=True, name="cat"),
+            ... )
+            >>> right = left.empty_like()
+            >>> left.fill(x=[0.2], cat="a")
+            >>> right.fill(x=[0.4], cat="a")
+            >>> merged = left + right
+        """
+        result = self.empty_like()
+        result += self
+        result += other
+        return result
+
+    def reset(self) -> None:
+        self._chunks.clear()
+        for spec in self.chunk_axes:
+            spec.known_keys.clear()

--- a/src/hist/chunked.py
+++ b/src/hist/chunked.py
@@ -115,7 +115,7 @@ def normalize_chunk_selection(
         else:
             values = tuple(
                 _normalize_chunk_scalar(value)
-                for value in tp.cast(Iterable[ChunkScalar], raw_value)
+                for value in tp.cast("Iterable[ChunkScalar]", raw_value)
             )
         if not values:
             raise ValueError(f"slice for axis {axis_name!r} must be non-empty")
@@ -393,7 +393,7 @@ class ChunkedHist:
             keys = keys_by_axis[spec.name]
             if issubclass(spec.axis_type, bh.axis.IntCategory):
                 axes[spec.index] = hist.axis.IntCategory(
-                    [tp.cast(int, key) for key in keys],
+                    [tp.cast("int", key) for key in keys],
                     name=spec.name,
                     label=spec.label,
                     metadata=spec.metadata,
@@ -402,7 +402,7 @@ class ChunkedHist:
                 )
             else:
                 axes[spec.index] = hist.axis.StrCategory(
-                    [tp.cast(str, key) for key in keys],
+                    [tp.cast("str", key) for key in keys],
                     name=spec.name,
                     label=spec.label,
                     metadata=spec.metadata,

--- a/src/hist/chunked.py
+++ b/src/hist/chunked.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import fnmatch
 import itertools
 import typing as tp
-from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -11,6 +10,11 @@ import boost_histogram as bh
 import numpy as np
 
 import hist
+
+if tp.TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
+    from ._compat.typing import Self
 
 __all__ = (
     "ChunkKey",
@@ -29,15 +33,23 @@ def _validate_supported_axis(axis: tp.Any) -> None:
         isinstance(axis, bh.axis.Regular)
         and getattr(axis, "transform", None) is not None
     ):
-        raise ValueError("ChunkedHist does not support transformed Regular axes yet")
+        msg = "ChunkedHist does not support transformed Regular axes yet"
+        raise ValueError(msg)
+    if (
+        not isinstance(axis, bh.axis.IntCategory | bh.axis.StrCategory)
+        and axis.traits.growth
+    ):
+        # Growth would reallocate the scratch histogram's buffer mid-fill,
+        # invalidating every stored chunk's shape.
+        msg = "ChunkedHist does not support growing dense axes"
+        raise ValueError(msg)
 
 
 def _validate_supported_storage(storage: tp.Any) -> None:
     storage_type = type(storage)
     if storage_type in {bh.storage.Mean, bh.storage.WeightedMean}:
-        raise ValueError(
-            f"ChunkedHist does not support {storage_type.__name__} storage yet"
-        )
+        msg = f"ChunkedHist does not support {storage_type.__name__} storage yet"
+        raise ValueError(msg)
 
 
 def _validate_dense_view(
@@ -48,13 +60,11 @@ def _validate_dense_view(
 ) -> np.ndarray:
     array = np.asarray(view)
     if array.shape != shape:
-        raise ValueError(
-            f"dense view shape mismatch: expected {shape}, got {array.shape}"
-        )
+        msg = f"dense view shape mismatch: expected {shape}, got {array.shape}"
+        raise ValueError(msg)
     if array.dtype != dtype:
-        raise ValueError(
-            f"dense view dtype mismatch: expected {dtype}, got {array.dtype}"
-        )
+        msg = f"dense view dtype mismatch: expected {dtype}, got {array.dtype}"
+        raise ValueError(msg)
     return array
 
 
@@ -74,13 +84,20 @@ def _zero_dense_view(view: np.ndarray) -> None:
         _zero_dense_view(view[field_name])
 
 
+def _view_any_nonzero(view: np.ndarray) -> bool:
+    if view.dtype.fields is None:
+        return bool(np.any(view))
+    return any(
+        _view_any_nonzero(view[field_name]) for field_name in view.dtype.names or ()
+    )
+
+
 def _normalize_chunk_scalar(value: tp.Any) -> ChunkScalar:
     if isinstance(value, np.generic):
         value = value.item()
     if not isinstance(value, str | int):
-        raise TypeError(
-            f"chunk axis values must normalize to str or int, got {type(value)=}"
-        )
+        msg = f"chunk axis values must normalize to str or int, got {type(value)=}"
+        raise TypeError(msg)
     return value
 
 
@@ -104,11 +121,11 @@ def normalize_chunk_selection(
 
     for axis_name, raw_value in selection.items():
         if axis_name not in known_axes:
-            raise KeyError(f"unknown axis in slice: {axis_name!r}")
+            msg = f"unknown axis in slice: {axis_name!r}"
+            raise KeyError(msg)
         if axis_name not in known_chunk_axes:
-            raise ValueError(
-                f"slicing only supports chunk axes; {axis_name!r} is dense"
-            )
+            msg = f"slicing only supports chunk axes; {axis_name!r} is dense"
+            raise ValueError(msg)
         values: tuple[ChunkScalar, ...]
         if _is_scalar_like(raw_value):
             values = (_normalize_chunk_scalar(raw_value),)
@@ -118,7 +135,8 @@ def normalize_chunk_selection(
                 for value in tp.cast("Iterable[ChunkScalar]", raw_value)
             )
         if not values:
-            raise ValueError(f"slice for axis {axis_name!r} must be non-empty")
+            msg = f"slice for axis {axis_name!r} must be non-empty"
+            raise ValueError(msg)
         normalized[axis_name] = values
 
     return normalized
@@ -173,9 +191,11 @@ class ChunkedHist:
             >>> h.fill(x=[0.2, 0.4], cat="a")
         """
         if not axes:
-            raise ValueError("ChunkedHist requires at least one axis")
+            msg = "ChunkedHist requires at least one axis"
+            raise ValueError(msg)
         if not all(getattr(axis, "name", None) for axis in axes):
-            raise ValueError("all axes must have names")
+            msg = "all axes must have names"
+            raise ValueError(msg)
         if storage is None:
             storage = bh.storage.Double()
         for axis in axes:
@@ -252,13 +272,29 @@ class ChunkedHist:
             chunked._save_chunk_view((), np.ascontiguousarray(source_view))
             return chunked
 
+        # ChunkedHist has no storage for chunk-axis flow bins; refuse to
+        # silently drop their contents.
+        for spec in chunked.chunk_axes:
+            source_axis = source.axes[spec.index]
+            if source_axis.extent == source_axis.size:
+                continue
+            selector: list[tp.Any] = [slice(None)] * source_view.ndim
+            selector[spec.index] = source_axis.size
+            if _view_any_nonzero(np.asarray(source_view[tuple(selector)])):
+                msg = (
+                    f"source histogram has content in the flow bin of "
+                    f"categorical axis {spec.name!r}; ChunkedHist does not "
+                    "store flow content for chunk axes"
+                )
+                raise ValueError(msg)
+
         if not any(spec.known_keys for spec in chunked.chunk_axes):
             return chunked
 
         for key_indices in itertools.product(
             *(range(len(spec.known_keys)) for spec in chunked.chunk_axes)
         ):
-            selector: list[tp.Any] = [slice(None)] * source_view.ndim
+            selector = [slice(None)] * source_view.ndim
             key_values: list[ChunkScalar] = []
             for spec, key_index in zip(chunked.chunk_axes, key_indices, strict=True):
                 selector[spec.index] = key_index
@@ -294,7 +330,18 @@ class ChunkedHist:
         )
         self._chunks[key] = np.array(array, copy=True, order="C")
 
+    def _check_chunk_key(self, key: ChunkKey) -> None:
+        for spec, key_part in zip(self.chunk_axes, key, strict=True):
+            if not spec.growth and key_part not in spec.known_keys:
+                msg = (
+                    f"unknown key {key_part!r} for non-growing chunk axis "
+                    f"{spec.name!r}; ChunkedHist does not store flow content "
+                    "for chunk axes"
+                )
+                raise ValueError(msg)
+
     def _remember_chunk_key(self, key: ChunkKey) -> None:
+        self._check_chunk_key(key)
         for spec, key_part in zip(self.chunk_axes, key, strict=True):
             if key_part not in spec.known_keys:
                 spec.known_keys.append(key_part)
@@ -304,15 +351,15 @@ class ChunkedHist:
     ) -> tuple[ChunkKey, dict[str, tp.Any]]:
         missing = [name for name in self.chunk_axis_names if name not in kwargs]
         if missing:
-            raise ValueError(f"missing chunk axes in fill kwargs: {missing!r}")
+            msg = f"missing chunk axes in fill kwargs: {missing!r}"
+            raise ValueError(msg)
 
         chunk_key: list[ChunkScalar] = []
         for name in self.chunk_axis_names:
             value = kwargs[name]
             if not _is_scalar_like(value):
-                raise ValueError(
-                    f"categorical chunk axis {name!r} only accepts scalar int/str values"
-                )
+                msg = f"categorical chunk axis {name!r} only accepts scalar int/str values"
+                raise ValueError(msg)
             chunk_key.append(_normalize_chunk_scalar(value))
 
         return tuple(chunk_key), {
@@ -322,6 +369,7 @@ class ChunkedHist:
         }
 
     def add_dense_view(self, key: ChunkKey, dense_view: np.ndarray) -> None:
+        self._check_chunk_key(key)
         dense_view = _validate_dense_view(
             dense_view,
             shape=self.dense_view_shape,
@@ -349,6 +397,7 @@ class ChunkedHist:
             >>> h.fill(x=[0.2, 0.4], cat="a")
         """
         chunk_key, dense_kwargs = self.split_fill_kwargs(kwargs)
+        self._check_chunk_key(chunk_key)
         dense_hist = self._scratch_dense_hist
         dense_view = dense_hist.view(flow=True)
         try:
@@ -486,16 +535,14 @@ class ChunkedHist:
         normalized = self._normalize_selection(selection)
         exact_key = self._exact_chunk_key(normalized)
         if exact_key is None:
-            raise ValueError(
-                "selection must provide exactly one value for each chunk axis"
-            )
+            msg = "selection must provide exactly one value for each chunk axis"
+            raise ValueError(msg)
         return exact_key
 
     def selection_dict(self, key: ChunkKey) -> dict[str, ChunkScalar]:
         if len(key) != len(self.chunk_axis_names):
-            raise ValueError(
-                f"chunk key must have {len(self.chunk_axis_names)} values, got {len(key)}"
-            )
+            msg = f"chunk key must have {len(self.chunk_axis_names)} values, got {len(key)}"
+            raise ValueError(msg)
         return {
             axis_name: key[index]
             for index, axis_name in enumerate(self.chunk_axis_names)
@@ -510,7 +557,8 @@ class ChunkedHist:
         try:
             return self._chunks[chunk_key]
         except KeyError as exc:
-            raise KeyError(f"chunk selection {exact_selection!r} not found") from exc
+            msg = f"chunk selection {exact_selection!r} not found"
+            raise KeyError(msg) from exc
 
     def __getitem__(
         self,
@@ -610,7 +658,7 @@ class ChunkedHist:
             f" # Chunks: {len(self)}, Bytes: {byte_str}"
         )
 
-    def __iadd__(self, other: ChunkedHist | hist.Hist[Any]) -> ChunkedHist:
+    def __iadd__(self, other: ChunkedHist | hist.Hist[Any]) -> Self:
         """Merge another compatible histogram into this one in place.
 
         Args:
@@ -638,18 +686,24 @@ class ChunkedHist:
             or self.name != other.name
             or self.label != other.label
         ):
-            raise ValueError("cannot add incompatible histograms")
+            msg = "cannot add incompatible histograms"
+            raise ValueError(msg)
 
         if not all(
             a == b for a, b in zip(self.dense_axes, other.dense_axes, strict=True)
         ):
-            raise ValueError("cannot add histograms with incompatible dense axes")
+            msg = "cannot add histograms with incompatible dense axes"
+            raise ValueError(msg)
 
         if not all(
             a.name == b.name and a.axis_type is b.axis_type
             for a, b in zip(self.chunk_axes, other.chunk_axes, strict=True)
         ):
-            raise ValueError("cannot add histograms with incompatible chunk axes")
+            msg = "cannot add histograms with incompatible chunk axes"
+            raise ValueError(msg)
+        # Validate every key first so a failure cannot leave a partial merge.
+        for key in other._chunks:
+            self._check_chunk_key(key)
         for key, dense_view in other._chunks.items():
             self.add_dense_view(key, dense_view)
         return self

--- a/src/hist/chunked.py
+++ b/src/hist/chunked.py
@@ -95,6 +95,8 @@ def _view_any_nonzero(view: np.ndarray) -> bool:
 def _normalize_chunk_scalar(value: tp.Any) -> ChunkScalar:
     if isinstance(value, np.generic):
         value = value.item()
+    if isinstance(value, bool):
+        return int(value)
     if not isinstance(value, str | int):
         msg = f"chunk axis values must normalize to str or int, got {type(value)=}"
         raise TypeError(msg)
@@ -481,8 +483,8 @@ class ChunkedHist:
 
         return merged
 
-    def empty_like(self) -> ChunkedHist:
-        return ChunkedHist(
+    def empty_like(self) -> Self:
+        return type(self)(
             *self.axes,
             storage=self.storage_type(),
             name=self.name,
@@ -490,8 +492,12 @@ class ChunkedHist:
         )
 
     def items(self) -> Iterable[tuple[ChunkKey, np.ndarray]]:
-        for key, chunk_view in self._chunks.items():
-            yield key, np.ascontiguousarray(chunk_view)
+        """Iterate over ``(chunk key, chunk array)`` pairs.
+
+        Like :meth:`chunk_view`, the yielded arrays are live views of the
+        internal storage; copy them if you need independent data.
+        """
+        yield from self._chunks.items()
 
     def _keys_by_axis(
         self,
@@ -552,6 +558,11 @@ class ChunkedHist:
         self,
         selection: Mapping[str, ChunkScalar | tp.Iterable[ChunkScalar]],
     ) -> np.ndarray:
+        """Return the live array for one chunk.
+
+        The returned array is a view of the internal storage; mutating it
+        mutates the histogram. Copy it if you need independent data.
+        """
         chunk_key = self.exact_chunk_key(selection)
         exact_selection = self.selection_dict(chunk_key)
         try:
@@ -627,7 +638,7 @@ class ChunkedHist:
         for result_spec in result.chunk_axes:
             result_spec.known_keys = keys_by_axis[result_spec.name]
         for key in matching_keys:
-            result._save_chunk_view(key, self._chunks[key].copy(order="C"))
+            result._save_chunk_view(key, self._chunks[key])
         return result
 
     def histogram_bytes(self) -> int:
@@ -648,9 +659,12 @@ class ChunkedHist:
     def __repr__(self) -> str:
         axes_repr = ",\n  ".join(repr(axis) for axis in self.axes)
         total_bytes = self.histogram_bytes()
-        byte_str = (
-            f"{total_bytes} B" if total_bytes < 1024 else f"{total_bytes / 1024:.1f} KB"
-        )
+        size = float(total_bytes)
+        for unit in ("B", "KB", "MB", "GB", "TB"):
+            if size < 1024 or unit == "TB":
+                break
+            size /= 1024
+        byte_str = f"{total_bytes} B" if unit == "B" else f"{size:.1f} {unit}"
         return (
             "ChunkedHist(\n"
             f"  {axes_repr},\n"

--- a/src/hist/chunked.py
+++ b/src/hist/chunked.py
@@ -109,12 +109,17 @@ def normalize_chunk_selection(
             raise ValueError(
                 f"slicing only supports chunk axes; {axis_name!r} is dense"
             )
-        values = (raw_value,) if isinstance(raw_value, str | int) else tuple(raw_value)
+        values: tuple[ChunkScalar, ...]
+        if _is_scalar_like(raw_value):
+            values = (_normalize_chunk_scalar(raw_value),)
+        else:
+            values = tuple(
+                _normalize_chunk_scalar(value)
+                for value in tp.cast(Iterable[ChunkScalar], raw_value)
+            )
         if not values:
             raise ValueError(f"slice for axis {axis_name!r} must be non-empty")
-        normalized[axis_name] = tuple(
-            _normalize_chunk_scalar(value) for value in values
-        )
+        normalized[axis_name] = values
 
     return normalized
 
@@ -283,13 +288,11 @@ class ChunkedHist:
 
     def _save_chunk_view(self, key: ChunkKey, chunk_view: np.ndarray) -> None:
         array = _validate_dense_view(
-            np.ascontiguousarray(chunk_view),
+            chunk_view,
             shape=self.dense_view_shape,
             dtype=self.dense_view_dtype,
         )
-        if not array.flags.writeable:
-            array = array.copy()
-        self._chunks[key] = array
+        self._chunks[key] = np.array(array, copy=True, order="C")
 
     def _remember_chunk_key(self, key: ChunkKey) -> None:
         for spec, key_part in zip(self.chunk_axes, key, strict=True):
@@ -379,7 +382,13 @@ class ChunkedHist:
         # TODO: implement native chunked UHI serialization that avoids
         # expensive materialization to a dense Hist.
         axes = list(self.axes)
-        keys_by_axis = self._keys_by_axis(self._chunks)
+        keys_from_chunks = self._keys_by_axis(self._chunks)
+        keys_by_axis = {
+            spec.name: list(
+                dict.fromkeys((*spec.known_keys, *keys_from_chunks[spec.name]))
+            )
+            for spec in self.chunk_axes
+        }
         for spec in self.chunk_axes:
             keys = keys_by_axis[spec.name]
             if issubclass(spec.axis_type, bh.axis.IntCategory):
@@ -545,8 +554,6 @@ class ChunkedHist:
                             for k in spec.known_keys
                             if isinstance(k, str) and fnmatch.fnmatch(k, pattern)
                         ]
-                        if not matches:
-                            raise ValueError(f"No matches found for {pattern!r}")
                         expanded.extend(matches)
                     else:
                         expanded.append(pattern)
@@ -591,13 +598,7 @@ class ChunkedHist:
         return key in self._chunks
 
     def __repr__(self) -> str:
-        axes_repr = ",\n  ".join(
-            # ChunkedHist categorical axes are always growable in practice
-            f"{type(axis).__name__}(..., growth=True, name={axis.name!r})"
-            if isinstance(axis, bh.axis.IntCategory | bh.axis.StrCategory)
-            else repr(axis)
-            for axis in self.axes
-        )
+        axes_repr = ",\n  ".join(repr(axis) for axis in self.axes)
         total_bytes = self.histogram_bytes()
         byte_str = (
             f"{total_bytes} B" if total_bytes < 1024 else f"{total_bytes / 1024:.1f} KB"

--- a/tests/test_chunked.py
+++ b/tests/test_chunked.py
@@ -593,6 +593,8 @@ def test_items():
     key, view = items_list[0]
     assert key == ("a",)
     assert isinstance(view, np.ndarray)
+    # items() yields live views, same as chunk_view()
+    assert view is h.chunk_view({"cat": "a"})
 
 
 # ---------------------------------------------------------------------------
@@ -607,6 +609,19 @@ def test_empty_like():
     empty = h.empty_like()
     assert len(empty) == 0
     assert empty.axes == h.axes
+
+
+def test_empty_like_preserves_subclass():
+    class SubHist(ChunkedHist):
+        pass
+
+    h = SubHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    assert type(h.empty_like()) is SubHist
+    assert type(h[{"cat": "a"}]) is SubHist
 
 
 def test_reset():
@@ -641,6 +656,15 @@ def test_repr():
     assert "cat" in r
     assert "Regular" in r
     assert "Chunks" in r
+
+
+def test_repr_large_sizes():
+    h = ChunkedHist(
+        axis.Regular(300_000, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")  # ~2.4 MB chunk
+    assert "MB" in repr(h)
 
 
 def test_repr_respects_axis_growth():
@@ -743,3 +767,15 @@ def test_int_category_with_numpy_scalar():
     h.fill(x=[0.1], icat=np.int64(42))
     assert len(h) == 1
     assert (42,) in h
+
+
+def test_bool_chunk_key_normalizes_to_int():
+    h = ChunkedHist(
+        axis.Regular(5, 0, 1, name="x"),
+        axis.IntCategory([], growth=True, name="icat"),
+    )
+    h.fill(x=[0.1], icat=True)
+    h.fill(x=[0.2], icat=np.True_)
+    assert list(h.keys()) == [(1,)]
+    key = next(iter(h.keys()))[0]
+    assert type(key) is int

--- a/tests/test_chunked.py
+++ b/tests/test_chunked.py
@@ -1,0 +1,617 @@
+from __future__ import annotations
+
+import boost_histogram as bh
+import numpy as np
+import pytest
+from pytest import approx
+
+import hist
+from hist import axis
+from hist.chunked import ChunkedHist
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+def test_constructor_basic():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    assert h.chunk_axis_names == ("cat",)
+    assert len(h) == 0
+    assert h.axes[0].name == "x"
+    assert h.axes[1].name == "cat"
+
+
+def test_constructor_int_category():
+    h = ChunkedHist(
+        axis.Regular(5, 0, 1, name="x"),
+        axis.IntCategory([], growth=True, name="icat"),
+    )
+    assert h.chunk_axis_names == ("icat",)
+    assert h.storage_type is bh.storage.Double
+
+
+def test_constructor_with_storage():
+    h = ChunkedHist(
+        axis.Regular(5, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="s"),
+        storage=bh.storage.Weight(),
+    )
+    assert h.storage_type is bh.storage.Weight
+
+
+def test_constructor_no_axes_raises():
+    with pytest.raises(ValueError, match="at least one axis"):
+        ChunkedHist()
+
+
+def test_constructor_unnamed_axes_raises():
+    with pytest.raises(ValueError, match="all axes must have names"):
+        ChunkedHist(axis.Regular(10, 0, 1))
+
+
+def test_constructor_transformed_axis_raises():
+    with pytest.raises(ValueError, match="transformed Regular axes"):
+        ChunkedHist(
+            axis.Regular(10, 0, 1, name="x", transform=axis.transform.sqrt),
+            axis.StrCategory([], growth=True, name="cat"),
+        )
+
+
+def test_constructor_unsupported_storage_raises():
+    # Mean and WeightedMean are not supported yet (see implementation note)
+    with pytest.raises(ValueError, match="Mean storage"):
+        ChunkedHist(
+            axis.Regular(10, 0, 1, name="x"),
+            axis.StrCategory([], growth=True, name="cat"),
+            storage=bh.storage.Mean(),
+        )
+    with pytest.raises(ValueError, match="WeightedMean storage"):
+        ChunkedHist(
+            axis.Regular(10, 0, 1, name="x"),
+            axis.StrCategory([], growth=True, name="cat"),
+            storage=bh.storage.WeightedMean(),
+        )
+
+
+def test_constructor_no_chunk_axes():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.Regular(5, 0, 1, name="y"),
+    )
+    assert h.chunk_axes == []
+    assert h.chunk_axis_names == ()
+
+
+# ---------------------------------------------------------------------------
+# Fill
+# ---------------------------------------------------------------------------
+def test_fill_basic():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2, 0.4], cat="a")
+    assert len(h) == 1
+    assert ("a",) in h
+    # Check counts via materialization
+    dense = h.to_hist()
+    assert dense[{"cat": "a", "x": bh.loc(0.2)}] == 1
+    assert dense[{"cat": "a", "x": bh.loc(0.4)}] == 1
+
+
+def test_fill_multiple_categories():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    h.fill(x=[0.3, 0.5], cat="b")
+    h.fill(x=[0.4], cat="a")
+
+    assert len(h) == 2
+    dense = h.to_hist()
+    assert dense[{"cat": "a", "x": bh.loc(0.2)}] == 1
+    assert dense[{"cat": "a", "x": bh.loc(0.4)}] == 1
+    assert dense[{"cat": "b", "x": bh.loc(0.3)}] == 1
+    assert dense[{"cat": "b", "x": bh.loc(0.5)}] == 1
+
+
+def test_fill_missing_chunk_axis_raises():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    with pytest.raises(ValueError, match="missing chunk axes"):
+        h.fill(x=[0.2])
+
+
+def test_fill_array_chunk_axis_raises():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    with pytest.raises(ValueError, match="only accepts scalar"):
+        h.fill(x=[0.2, 0.4], cat=["a", "b"])
+
+
+def test_fill_weight():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+        storage=bh.storage.Weight(),
+    )
+    h.fill(x=[0.2, 0.4], cat="a", weight=[1.0, 2.0])
+    dense = h.to_hist()
+    assert dense[{"cat": "a", "x": bh.loc(0.2)}].variance == approx(1.0)
+    assert dense[{"cat": "a", "x": bh.loc(0.4)}].variance == approx(4.0)
+
+
+def test_fill_int_category():
+    h = ChunkedHist(
+        axis.Regular(5, 0, 1, name="x"),
+        axis.IntCategory([], growth=True, name="icat"),
+    )
+    h.fill(x=[0.1], icat=42)
+    h.fill(x=[0.2], icat=7)
+    assert len(h) == 2
+    dense = h.to_hist()
+    assert dense[{"icat": bh.loc(42), "x": bh.loc(0.1)}] == 1
+    assert dense[{"icat": bh.loc(7), "x": bh.loc(0.2)}] == 1
+
+
+def test_fill_no_chunk_axes():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+    )
+    h.fill(x=[0.2, 0.4])
+    assert len(h) == 1
+    dense = h.to_hist()
+    assert dense[{"x": bh.loc(0.2)}] == 1
+    assert dense[{"x": bh.loc(0.4)}] == 1
+
+
+# ---------------------------------------------------------------------------
+# to_hist / from_hist
+# ---------------------------------------------------------------------------
+def test_to_hist_empty():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    dense = h.to_hist()
+    assert isinstance(dense, hist.Hist)
+    assert dense.ndim == 2
+    assert len(dense.axes[1]) == 0
+
+
+def test_from_hist_basic():
+    source = hist.Hist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], growth=True, name="cat"),
+    )
+    source.fill(x=[0.2, 0.4], cat=["a", "a"])
+    chunked = ChunkedHist.from_hist(source)
+    assert len(chunked) == 1
+    dense = chunked.to_hist()
+    assert dense[{"x": bh.loc(0.2), "cat": "a"}] == 1
+    assert dense[{"x": bh.loc(0.4), "cat": "a"}] == 1
+
+
+def test_from_hist_multiple_categories():
+    source = hist.Hist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a", "b"], growth=True, name="cat"),
+    )
+    source.fill(x=[0.1, 0.2, 0.3], cat=["a", "a", "b"])
+    chunked = ChunkedHist.from_hist(source)
+    assert len(chunked) == 2
+    dense = chunked.to_hist()
+    assert dense[{"x": bh.loc(0.1), "cat": "a"}] == 1
+    assert dense[{"x": bh.loc(0.2), "cat": "a"}] == 1
+    assert dense[{"x": bh.loc(0.3), "cat": "b"}] == 1
+
+
+def test_round_trip():
+    chunked = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    chunked.fill(x=[0.2, 0.4], cat="a")
+    chunked.fill(x=[0.3], cat="b")
+
+    dense = chunked.to_hist()
+    recovered = ChunkedHist.from_hist(dense)
+    assert len(recovered) == len(chunked)
+    for key in chunked:
+        np.testing.assert_array_equal(
+            recovered.chunk_view({"cat": key[0]}),
+            chunked.chunk_view({"cat": key[0]}),
+        )
+
+
+def test_from_hist_no_chunk_axes():
+    source = hist.Hist(axis.Regular(5, 0, 1, name="x"))
+    source.fill(x=[0.1, 0.2, 0.3])
+    chunked = ChunkedHist.from_hist(source)
+    assert len(chunked) == 1
+    dense = chunked.to_hist()
+    assert np.sum(dense.values()) == 3
+
+
+# ---------------------------------------------------------------------------
+# Merging
+# ---------------------------------------------------------------------------
+def test_iadd_chunked():
+    left = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    right = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    left.fill(x=[0.2], cat="a")
+    right.fill(x=[0.4], cat="a")
+    right.fill(x=[0.5], cat="b")
+
+    left += right
+    assert len(left) == 2
+    dense = left.to_hist()
+    assert dense[{"x": bh.loc(0.2), "cat": "a"}] == 1
+    assert dense[{"x": bh.loc(0.4), "cat": "a"}] == 1
+    assert dense[{"x": bh.loc(0.5), "cat": "b"}] == 1
+
+
+def test_add_chunked():
+    left = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    right = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    left.fill(x=[0.2], cat="a")
+    right.fill(x=[0.4], cat="a")
+
+    merged = left + right
+    assert len(merged) == 1
+    dense = merged.to_hist()
+    assert dense[{"x": bh.loc(0.2), "cat": "a"}] == 1
+    assert dense[{"x": bh.loc(0.4), "cat": "a"}] == 1
+
+
+def test_iadd_hist():
+    chunked = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    dense = hist.Hist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], growth=True, name="cat"),
+    )
+    chunked.fill(x=[0.2], cat="a")
+    dense.fill(x=[0.4], cat="a")
+
+    chunked += dense
+    result = chunked.to_hist()
+    assert result[{"x": bh.loc(0.2), "cat": "a"}] == 1
+    assert result[{"x": bh.loc(0.4), "cat": "a"}] == 1
+
+
+def test_add_incompatible_raises():
+    left = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    right = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="different"),
+    )
+    with pytest.raises(ValueError, match="incompatible chunk axes"):
+        left + right
+
+
+# ---------------------------------------------------------------------------
+# Selection (__getitem__)
+# ---------------------------------------------------------------------------
+def test_getitem_single_value():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    h.fill(x=[0.4], cat="b")
+
+    only_a = h[{"cat": "a"}]
+    assert len(only_a) == 1
+    assert ("a",) in only_a
+    dense = only_a.to_hist()
+    assert dense[{"x": bh.loc(0.2), "cat": "a"}] == 1
+
+
+def test_getitem_multiple_values():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    h.fill(x=[0.4], cat="b")
+    h.fill(x=[0.6], cat="c")
+
+    ab = h[{"cat": ("a", "b")}]
+    assert len(ab) == 2
+    assert ("a",) in ab
+    assert ("b",) in ab
+    assert ("c",) not in ab
+
+
+def test_getitem_wildcard():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="apple")
+    h.fill(x=[0.4], cat="apricot")
+    h.fill(x=[0.6], cat="banana")
+
+    selected = h[{"cat": "ap*"}]
+    assert len(selected) == 2
+
+
+def test_getitem_wildcard_question():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a1")
+    h.fill(x=[0.4], cat="a2")
+    h.fill(x=[0.6], cat="b1")
+
+    selected = h[{"cat": "a?"}]
+    assert len(selected) == 2
+
+
+def test_getitem_non_chunk_axis_raises():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    with pytest.raises(ValueError, match="dense"):
+        h[{"x": 1}]
+
+
+def test_getitem_unknown_axis_raises():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    with pytest.raises(KeyError, match="unknown axis"):
+        h[{"foo": "a"}]
+
+
+def test_getitem_empty_result():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    empty = h[{"cat": "nonexistent"}]
+    assert len(empty) == 0
+
+
+def test_getitem_multiple_chunk_axes():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="s"),
+        axis.IntCategory([], growth=True, name="i"),
+    )
+    h.fill(x=[0.2], s="a", i=1)
+    h.fill(x=[0.4], s="b", i=2)
+    h.fill(x=[0.6], s="a", i=2)
+
+    selected = h[{"s": "a"}]
+    assert len(selected) == 2
+    dense = selected.to_hist()
+    assert dense[{"s": "a", "i": bh.loc(1), "x": bh.loc(0.2)}] == 1
+    assert dense[{"s": "a", "i": bh.loc(2), "x": bh.loc(0.6)}] == 1
+
+
+# ---------------------------------------------------------------------------
+# Chunk access
+# ---------------------------------------------------------------------------
+def test_chunk_view():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2, 0.4], cat="a")
+
+    view = h.chunk_view({"cat": "a"})
+    assert isinstance(view, np.ndarray)
+    # The scratch dense hist does not include chunk axes
+    assert view.ndim == 1
+    assert view.shape[0] == 12  # 10 bins + 2 flow
+
+
+def test_chunk_view_missing():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    with pytest.raises(KeyError, match="not found"):
+        h.chunk_view({"cat": "missing"})
+
+
+def test_keys_len_contains():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    h.fill(x=[0.4], cat="b")
+
+    assert len(h) == 2
+    keys_list = list(h.keys())
+    assert ("a",) in keys_list
+    assert ("b",) in keys_list
+    assert ("a",) in h
+    assert ("z",) not in h
+
+
+def test_items():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    items_list = list(h.items())
+    assert len(items_list) == 1
+    key, view = items_list[0]
+    assert key == ("a",)
+    assert isinstance(view, np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+def test_empty_like():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    empty = h.empty_like()
+    assert len(empty) == 0
+    assert empty.axes == h.axes
+
+
+def test_reset():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    assert len(h) == 1
+    h.reset()
+    assert len(h) == 0
+    assert ("a",) not in h
+
+
+def test_histogram_bytes():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    assert h.histogram_bytes() == 0
+    h.fill(x=[0.2], cat="a")
+    assert h.histogram_bytes() > 0
+
+
+def test_repr():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    r = repr(h)
+    assert "ChunkedHist" in r
+    assert "cat" in r
+    assert "Regular" in r
+    assert "Chunks" in r
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+def test_dense_view_shape_dtype():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.Regular(5, 0, 1, name="y"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    assert h.dense_view_shape == (12, 7)  # +2 flow on each
+    assert h.dense_view_dtype == np.dtype("float64")
+
+
+def test_dense_axes():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    dense = h.dense_axes
+    assert len(dense) == 1
+    assert dense[0].name == "x"
+
+
+# ---------------------------------------------------------------------------
+# Exact chunk key helpers
+# ---------------------------------------------------------------------------
+def test_exact_chunk_key():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    key = h.exact_chunk_key({"cat": "a"})
+    assert key == ("a",)
+
+
+def test_selection_dict():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    d = h.selection_dict(("a",))
+    assert d == {"cat": "a"}
+
+
+def test_exact_chunk_key_multiple_values_raises():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    with pytest.raises(ValueError, match="exactly one value"):
+        h.exact_chunk_key({"cat": ("a", "b")})
+
+
+# ---------------------------------------------------------------------------
+# Copy / pickle-like behavior
+# ---------------------------------------------------------------------------
+def test_to_hist_copy_independence():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    dense1 = h.to_hist()
+    dense2 = h.to_hist()
+    # Mutating one should not affect the other
+    dense2[{"cat": "a", "x": 0}] = 99
+    assert dense1[{"cat": "a", "x": 0}] == 0
+
+
+def test_iadd_modifies_in_place():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="a")
+    original_id = id(h)
+    h += h.empty_like()
+    assert id(h) == original_id
+
+
+# ---------------------------------------------------------------------------
+# str/int normalization
+# ---------------------------------------------------------------------------
+def test_int_category_with_numpy_scalar():
+    h = ChunkedHist(
+        axis.Regular(5, 0, 1, name="x"),
+        axis.IntCategory([], growth=True, name="icat"),
+    )
+    # numpy scalar int should be accepted as chunk key
+    h.fill(x=[0.1], icat=np.int64(42))
+    assert len(h) == 1
+    assert (42,) in h

--- a/tests/test_chunked.py
+++ b/tests/test_chunked.py
@@ -187,6 +187,16 @@ def test_to_hist_empty():
     assert len(dense.axes[1]) == 0
 
 
+def test_to_hist_preserves_declared_categories_without_chunks():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a", "b"], growth=False, name="cat"),
+    )
+    dense = h.to_hist()
+    assert list(dense.axes[1]) == ["a", "b"]
+    assert not dense.axes[1].traits.growth
+
+
 def test_from_hist_basic():
     source = hist.Hist(
         axis.Regular(10, 0, 1, name="x"),
@@ -263,6 +273,23 @@ def test_iadd_chunked():
     assert dense[{"x": bh.loc(0.2), "cat": "a"}] == 1
     assert dense[{"x": bh.loc(0.4), "cat": "a"}] == 1
     assert dense[{"x": bh.loc(0.5), "cat": "b"}] == 1
+
+
+def test_iadd_chunked_does_not_alias_source_chunk_arrays():
+    left = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    right = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    right.fill(x=[0.5], cat="b")
+
+    left += right
+    right.chunk_view({"cat": "b"})[...] = 0
+
+    assert left.to_hist()[{"x": bh.loc(0.5), "cat": "b"}] == 1
 
 
 def test_add_chunked():
@@ -375,6 +402,16 @@ def test_getitem_wildcard_question():
     assert len(selected) == 2
 
 
+def test_getitem_wildcard_no_match_returns_empty():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory([], growth=True, name="cat"),
+    )
+    h.fill(x=[0.2], cat="apple")
+    selected = h[{"cat": "z*"}]
+    assert len(selected) == 0
+
+
 def test_getitem_non_chunk_axis_raises():
     h = ChunkedHist(
         axis.Regular(10, 0, 1, name="x"),
@@ -418,6 +455,17 @@ def test_getitem_multiple_chunk_axes():
     dense = selected.to_hist()
     assert dense[{"s": "a", "i": bh.loc(1), "x": bh.loc(0.2)}] == 1
     assert dense[{"s": "a", "i": bh.loc(2), "x": bh.loc(0.6)}] == 1
+
+
+def test_getitem_numpy_scalar_selection():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.IntCategory([], growth=True, name="icat"),
+    )
+    h.fill(x=[0.2], icat=42)
+    selected = h[{"icat": np.int64(42)}]
+    assert len(selected) == 1
+    assert (42,) in selected
 
 
 # ---------------------------------------------------------------------------
@@ -521,6 +569,14 @@ def test_repr():
     assert "cat" in r
     assert "Regular" in r
     assert "Chunks" in r
+
+
+def test_repr_respects_axis_growth():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], growth=False, name="cat"),
+    )
+    assert "growth=True, name='cat'" not in repr(h)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chunked.py
+++ b/tests/test_chunked.py
@@ -76,6 +76,20 @@ def test_constructor_unsupported_storage_raises():
         )
 
 
+def test_constructor_growing_dense_axis_raises():
+    # Growth would reallocate the scratch buffer mid-fill, invalidating chunks
+    with pytest.raises(ValueError, match="growing dense axes"):
+        ChunkedHist(
+            axis.Regular(10, 0, 1, name="x", growth=True),
+            axis.StrCategory([], growth=True, name="cat"),
+        )
+    with pytest.raises(ValueError, match="growing dense axes"):
+        ChunkedHist(
+            axis.Integer(0, 5, name="i", growth=True),
+            axis.StrCategory([], growth=True, name="cat"),
+        )
+
+
 def test_constructor_no_chunk_axes():
     h = ChunkedHist(
         axis.Regular(10, 0, 1, name="x"),
@@ -162,6 +176,24 @@ def test_fill_int_category():
     assert dense[{"icat": bh.loc(7), "x": bh.loc(0.2)}] == 1
 
 
+def test_fill_unknown_key_non_growing_raises():
+    h = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], name="cat"),  # growth=False
+    )
+    h.fill(x=[0.2], cat="a")
+    with pytest.raises(ValueError, match="non-growing chunk axis"):
+        h.fill(x=[0.4], cat="z")
+    # The failed fill must not leave any trace
+    assert list(h.keys()) == [("a",)]
+    h.fill(x=[0.6], cat="a")
+    dense = h.to_hist()
+    assert list(dense.axes[1]) == ["a"]
+    assert dense[{"cat": "a", "x": bh.loc(0.2)}] == 1
+    assert dense[{"cat": "a", "x": bh.loc(0.4)}] == 0
+    assert dense[{"cat": "a", "x": bh.loc(0.6)}] == 1
+
+
 def test_fill_no_chunk_axes():
     h = ChunkedHist(
         axis.Regular(10, 0, 1, name="x"),
@@ -240,6 +272,46 @@ def test_round_trip():
             recovered.chunk_view({"cat": key[0]}),
             chunked.chunk_view({"cat": key[0]}),
         )
+
+
+def test_from_hist_categorical_flow_content_raises():
+    source = hist.Hist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], name="cat"),  # growth=False, has overflow
+    )
+    source.fill(x=[0.2, 0.4], cat=["a", "z"])  # "z" lands in the flow bin
+    with pytest.raises(ValueError, match="flow bin of categorical axis 'cat'"):
+        ChunkedHist.from_hist(source)
+
+
+def test_from_hist_empty_flow_ok():
+    source = hist.Hist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], name="cat"),
+    )
+    source.fill(x=[0.2], cat=["a"])
+    chunked = ChunkedHist.from_hist(source)
+    assert chunked.to_hist()[{"cat": "a", "x": bh.loc(0.2)}] == 1
+
+
+def test_iadd_unknown_key_non_growing_is_atomic():
+    left = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a"], name="cat"),
+    )
+    right = ChunkedHist(
+        axis.Regular(10, 0, 1, name="x"),
+        axis.StrCategory(["a", "z"], name="cat"),
+    )
+    left.fill(x=[0.2], cat="a")
+    right.fill(x=[0.4], cat="a")
+    right.fill(x=[0.5], cat="z")
+
+    with pytest.raises(ValueError, match="non-growing chunk axis"):
+        left += right
+    # No partial merge: left is untouched
+    assert list(left.keys()) == [("a",)]
+    assert left.to_hist()[{"cat": "a", "x": bh.loc(0.4)}] == 0
 
 
 def test_from_hist_no_chunk_axes():


### PR DESCRIPTION
Close #684.

<details><summary>:robot: Suggested followups</summary>
<p>

Here are the natural followups, roughly ordered by impact vs. effort:

---

### 1. **Top-level export** (`from hist import ChunkedHist`)
Currently only `from hist.chunked import ChunkedHist` works. Adding it to `hist/__init__.py` is trivial and would make it discoverable.

---

### 2. **Array-valued chunk axes in `fill()`**
Right now `fill()` requires scalar chunk-axis values:
```python
h.fill(x=[0.1, 0.2], cat="a")   # OK
h.fill(x=[0.1, 0.2], cat=["a", "b"])  # raises
```
Supporting array-valued chunk axes would group by chunk key and dispatch to multiple chunks in one call. This is a common user expectation.

**Tradeoff**: More complex because you need to group the dense-axis data by chunk key and call `dense_hist.fill()` per group.

---

### 3. **Native chunked UHI serialization**
Right now round-tripping through JSON/bytes requires `to_hist()` first, which is expensive for large histograms. A native format that serializes chunk metadata + individual chunk arrays would avoid materialization.

---

### 4. **Custom `__getstate__` / `__setstate__`**
For pickle/dill interop. Without this, pickling a `ChunkedHist` won't work correctly (it has unpicklable internal state like the scratch hist reference).

---

### 5. **`Reporter`-style operations: `*`, `-`, `/`, `**`**
Only `+` / `+=` are implemented. Multiplication, subtraction, division could be useful for e.g. weighted subtraction of backgrounds.

---

### 6. **Relax `Mean` / `WeightedMean` storage restriction**
The scratch-histogram reuse trick is trickier with structured storages, but it's solvable with per-field accumulation.

---

### 7. **Support transformed `Regular` axes**
Currently `Regular(..., transform=...)` is rejected. This is just a validation gate that can be lifted once tested.

---

### 8. **Thread-safe filling**
The current `fill()` reuses a single scratch `Hist` per instance. Parallel filling from multiple threads would race on that scratch buffer. Options:
- A thread-local scratch buffer
- A lock around `fill()`
- Remove the scratch buffer entirely and create a temporary `Hist` per fill (slower but simpler)

---

### 9. **`chunk_view()` on missing keys returns zeros instead of raising**
Currently missing chunks raise `KeyError`. Some workflows might prefer getting a zeroed view for missing chunks (like `dict.get()`).

---

### 10. **Documentation page**
A short user-guide section explaining when to reach for `ChunkedHist` vs. plain `Hist` vs. `dask` hist.

---

### My suggestion for priority order
1. Top-level export (trivial, high visibility)
2. Pickle support (needed for real workflows)
3. Array-valued chunk axes (biggest UX improvement)
4. Native serialization (needed for large-scale I/O)
5. Thread safety (needed for parallel analysis)

What resonates with you?

</p>
</details> 

:robot: Assisted-by: Kimi-K2.6
