### PR TITLE
chore: add more Ruff codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,6 @@ warn_unreachable = true
 module = [
     "histoprint.*",
     "scipy.optimize.*",
-    "uncertainties.*",
     "matplotlib.*",
     "scipy.*",
     "iminuit.*",
@@ -200,31 +199,49 @@ messages_control.disable = [
 
 [tool.ruff.lint]
 extend-select = [
-  "B",           # flake8-bugbear
-  "I",           # isort
+  "A",           # flake8-builtins
   "ARG",         # flake8-unused-arguments
+  "B",           # flake8-bugbear
+  "BLE",         # flake8-blind-except
   "C4",          # flake8-comprehensions
+  "DTZ",         # flake8-datetimez
+  "EM",          # flake8-errmsg
+  "EXE",         # flake8-executable
+  "FA",          # flake8-future-annotations
+  "FLY",         # flynt
+  "FURB",        # refurb
+  "G",           # flake8-logging-format
+  "I",           # isort
   "ICN",         # flake8-import-conventions
   "ISC",         # flake8-implicit-str-concat
+  "LOG",         # flake8-logging
+  "PERF",        # Perflint
   "PGH",         # pygrep-hooks
   "PIE",         # flake8-pie
   "PL",          # pylint
   "PT",          # flake8-pytest-style
   "PTH",         # flake8-use-pathlib
+  "PYI",         # flake8-pyi
+  "Q",           # flake8-quotes
   "RET",         # flake8-return
+  "RSE",         # flake8-raise
   "RUF",         # Ruff-specific
   "SIM",         # flake8-simplify
+  "SLOT",        # flake8-slots
+  "T10",         # flake8-debugger
   "T20",         # flake8-print
+  "TC",          # flake8-type-checking
+  "TRY",         # tryceratops
   "UP",          # pyupgrade
   "YTT",         # flake8-2020
 ]
-ignore = ["PLR", "E501", "PT011", "PT013", "B017", "PLC0415"]
+ignore = ["PLR", "E501", "PT011", "PT013", "B017", "PLC0415", "PERF203", "A004"]
 typing-modules = ["hist._compat.typing"]
 isort.required-imports = ["from __future__ import annotations"]
 flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/test_plot.py" = ["B008"]
-"docs/conf.py" = ["ARG001", "PTH"]
+"docs/conf.py" = ["ARG001", "PTH", "A001"]
 "noxfile.py" = ["T20"]
-"**.ipynb" = ["B008", "T20", "I002", "E402", "E703", "B018"]
+"**.ipynb" = ["B008", "T20", "I002", "E402", "E703", "B018", "PERF401"]

--- a/src/hist/__init__.py
+++ b/src/hist/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import warnings
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 from . import accumulators, axis, numpy, storage, tag
 from .basehist import BaseHist
@@ -23,6 +23,9 @@ from .tag import (
 
 # Convenient access to the version number
 from .version import version as __version__
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 __all__ = (
     "BaseHist",
@@ -56,4 +59,5 @@ def __getattr__(name: str) -> ModuleType:
         msg = f"Misspelling error, '{name}' should be 'axis'"
         warnings.warn(msg, stacklevel=2)
         return axis
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+    msg_0 = f"module {__name__} has no attribute {name}"
+    raise AttributeError(msg_0)

--- a/src/hist/axestuple.py
+++ b/src/hist/axestuple.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from boost_histogram.axis import ArrayTuple, AxesTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 __all__ = ("ArrayTuple", "AxesTuple", "NamedAxesTuple")
 
@@ -23,7 +25,8 @@ class NamedAxesTuple(AxesTuple):
         for i, ax in enumerate(self):
             if ax.name == name:
                 return i
-        raise KeyError(f"{name} not found in axes")
+        msg = f"{name} not found in axes"
+        raise KeyError(msg)
 
     def __getitem__(self, item: Any) -> Any:
         if isinstance(item, slice):
@@ -59,9 +62,8 @@ class NamedAxesTuple(AxesTuple):
 
         valid_names = [ax.name for ax in self if ax.name]
         if len(valid_names) != len(set(valid_names)):
-            raise KeyError(
-                f"{self.__class__.__name__} instance cannot contain axes with duplicated names"
-            )
+            msg = f"{self.__class__.__name__} instance cannot contain axes with duplicated names"
+            raise KeyError(msg)
 
     @property
     def label(self) -> tuple[str]:

--- a/src/hist/axis/__init__.py
+++ b/src/hist/axis/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Iterable
 from typing import Any, Protocol
 
 import boost_histogram.axis as bha
@@ -10,6 +9,9 @@ import hist
 
 from ..axestuple import ArrayTuple, NamedAxesTuple
 from . import transform
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable
 
 __all__ = (
     "ArrayTuple",
@@ -61,7 +63,7 @@ class AxesMixin:
         """
         Get the name for the Regular axis
         """
-        return typing.cast(str, self._raw_metadata.get("name", ""))
+        return typing.cast("str", self._raw_metadata.get("name", ""))
 
     @property
     def label(self: AxisProtocol) -> str:

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -18,7 +18,6 @@ import packaging.version
 import hist
 
 from . import interop
-from ._compat.typing import ArrayLike, Self
 from .axestuple import NamedAxesTuple
 from .axis import AxisProtocol
 from .quick_construct import MetaConstructor
@@ -31,11 +30,12 @@ if typing.TYPE_CHECKING:
     import matplotlib.axes
     from mplhep.plot import Hist1DArtists, Hist2DArtists
 
+    from ._compat.typing import ArrayLike, Self
     from .plot import FitResultArtists, MainAxisArtists, RatiolikeArtists
 
 
 class SupportsLessThan(Protocol):
-    def __lt__(self, __other: Any) -> bool: ...
+    def __lt__(self, other: Any, /) -> bool: ...
 
 
 InnerIndexing = Union[
@@ -187,9 +187,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
 
         valid_names = [ax.name for ax in self.axes if ax.name]
         if len(valid_names) != len(set(valid_names)):
-            raise KeyError(
-                f"{self.__class__.__name__} instance cannot contain axes with duplicated names"
-            )
+            msg_0 = f"{self.__class__.__name__} instance cannot contain axes with duplicated names"
+            raise KeyError(msg_0)
         for i, ax in enumerate(self.axes):
             # label will return name if label is not set, so this is safe
             if not ax.label:
@@ -243,7 +242,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             if name == axis.name:
                 return index
 
-        raise ValueError(f"The axis name {name} could not be found")
+        msg = f"The axis name {name} could not be found"
+        raise ValueError(msg)
 
     def _to_uhi_(self) -> dict[str, Any]:
         from .serialization import to_uhi
@@ -269,11 +269,11 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
                 elif all(isinstance(a, int) for a in cats):
                     axes_list.append(hist.axis.IntCategory(sorted(cats), name=ax))  # type: ignore[arg-type]
                 else:
-                    raise TypeError(
-                        f"{ax} must be all int or strings if axis not given"
-                    )
+                    msg = f"{ax} must be all int or strings if axis not given"
+                    raise TypeError(msg)
             elif not ax.name or ax.name not in data:
-                raise TypeError("All axes must have names present in the data")
+                msg = "All axes must have names present in the data"
+                raise TypeError(msg)
             else:
                 axes_list.append(ax)
 
@@ -327,10 +327,11 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             missing = expected - provided
             missing_values = [self.axes[i].name for i in missing]
 
-            raise TypeError(
+            msg_0 = (
                 f"Missing values for single/multiple axis : {missing_values}."
                 f"Expected axes : {[ax.name for ax in self.axes]}"
             )
+            raise TypeError(msg_0)
 
         data = (data_dict[i] for i in range(len(args), self.ndim))
 
@@ -436,16 +437,15 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             return x
         if any(any(special in pattern for special in ["*", "?"]) for pattern in _x):
             available = [n for n in self.axes[ax_id] if isinstance(n, str)]
-            all_matches = []
-            for pattern in _x:
-                all_matches.append(
-                    [k for k in available if fnmatch.fnmatch(k, pattern)]
-                )
+            all_matches = [
+                [k for k in available if fnmatch.fnmatch(k, pattern)] for pattern in _x
+            ]
             matches = list(
                 dict.fromkeys(list(itertools.chain.from_iterable(all_matches)))
             )
             if len(matches) == 0:
-                raise ValueError(f"No matches found for {x}")
+                msg = f"No matches found for {x}"
+                raise ValueError(msg)
             return matches
         return x
 
@@ -464,7 +464,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             )
         if isinstance(x, complex):
             if x.real % 1 != 0:
-                raise ValueError("The real part should be an integer")
+                msg = "The real part should be an integer"
+                raise ValueError(msg)
             return bh.loc(x.imag, int(x.real))
         if isinstance(x, str):
             return bh.loc(x)
@@ -480,9 +481,11 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             return x
 
         if x.real != 0:
-            raise ValueError("The step should not have real part")
+            msg = "The step should not have real part"
+            raise ValueError(msg)
         if x.imag % 1 != 0:
-            raise ValueError("The imaginary part should be an integer")
+            msg = "The imaginary part should be an integer"
+            raise ValueError(msg)
         return bh.rebin(int(x.imag))
 
     def _index_transform(self, index: list[IndexingExpr] | IndexingExpr) -> Any:
@@ -498,9 +501,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
                 for k, v in index.items()
             }
             if len(new_indices) != len(index):
-                raise ValueError(
-                    "Duplicate index keys, numbers and names cannot overlap"
-                )
+                msg = "Duplicate index keys, numbers and names cannot overlap"
+                raise ValueError(msg)
             return new_indices
 
         if not isinstance(index, tuple):
@@ -565,7 +567,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         """
 
         if self.kind != bh.Kind.COUNT:
-            raise TypeError("Profile requires a COUNT histogram")
+            msg = "Profile requires a COUNT histogram"
+            raise TypeError(msg)
 
         axes = list(self.axes)
         iaxis = axis if isinstance(axis, int) else self._name_to_index(axis)
@@ -624,7 +627,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         if self.ndim == 2:
             return self.plot2d(*args, **kwargs)
 
-        raise NotImplementedError("Please project to 1D or 2D before calling plot")
+        msg = "Please project to 1D or 2D before calling plot"
+        raise NotImplementedError(msg)
 
     def plot1d(
         self,
@@ -677,9 +681,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
                 cats = [kwargs["label"]] * len(cats)
                 kwargs.pop("label")
             else:
-                raise ValueError(
-                    f"label ``{kwargs['label']}`` not understood for {len(cats)} categories"
-                )
+                msg = f"label ``{kwargs['label']}`` not understood for {len(cats)} categories"
+                raise ValueError(msg)
         artists = plot.histplot(d1hists, ax=ax, label=cats, **_proc_kw_for_lw(kwargs))
         if legend:
             # Try to set legend title from axis label if available
@@ -691,7 +694,7 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             handles, _ = ax.get_legend_handles_labels()
             if handles:
                 title = getattr(cat_ax, "label", None)
-                ax.legend(title=title if title else None)
+                ax.legend(title=title or None)
         return artists
 
     def plot2d(
@@ -780,7 +783,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         Returns a stack from a normal histogram axes.
         """
         if self.ndim < 2:
-            raise RuntimeError("Cannot stack with less than two axis")
+            msg = "Cannot stack with less than two axis"
+            raise RuntimeError(msg)
         stack_histograms: Iterator[BaseHist[S]] = [  # type: ignore[assignment]
             self[{axis: i}] for i in range(len(self.axes[axis]))
         ]

--- a/src/hist/dask/__init__.py
+++ b/src/hist/dask/__init__.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import importlib.util
 
 if not importlib.util.find_spec("dask_histogram"):
-    raise ModuleNotFoundError(
-        """for hist.dask, install the 'dask_histogram' package with:
+    msg = """for hist.dask, install the 'dask_histogram' package with:
         pip install dask_histogram
         or
         conda install dask_histogram"""
-    )
+    raise ModuleNotFoundError(msg)
 
 from .hist import Hist
 from .namedhist import NamedHist

--- a/src/hist/interop.py
+++ b/src/hist/interop.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence
-from typing import Any, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 
 import numpy as np
 
-from ._compat.typing import ArrayLike
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
+
+    from ._compat.typing import ArrayLike
 
 T_contra = TypeVar("T_contra", contravariant=True)
 U = TypeVar("U")
@@ -64,7 +66,8 @@ def destructure(obj: Any) -> dict[str, Any] | None:
     """
     for module in find_histogram_modules(obj):
         return module.unpack(obj)
-    raise TypeError(f"No histogram module found for {obj!r}")
+    msg = f"No histogram module found for {obj!r}"
+    raise TypeError(msg)
 
 
 def broadcast_and_flatten(
@@ -84,7 +87,8 @@ def broadcast_and_flatten(
             it = iter(result)
             return tuple(next(it) if not isinstance(x, str) else x for x in args)
 
-    raise TypeError(f"No histogram module found for {args!r}")
+    msg = f"No histogram module found for {args!r}"
+    raise TypeError(msg)
 
 
 @histogram_module_for(np.ndarray)
@@ -121,7 +125,7 @@ else:
     class PandasHistogramModule:
         @staticmethod
         def unpack(obj: pd.DataFrame) -> dict[str, pd.Series[Any]]:
-            return cast(dict[str, pd.Series[Any]], obj.to_dict("series"))
+            return cast("dict[str, pd.Series[Any]]", obj.to_dict("series"))
 
         @staticmethod
         def broadcast_and_flatten(

--- a/src/hist/intervals.py
+++ b/src/hist/intervals.py
@@ -99,9 +99,8 @@ def clopper_pearson_interval(
         coverage = stats.norm.cdf(1) - stats.norm.cdf(-1)
     # Numerator is subset of denominator
     if np.any(num > denom):
-        raise ValueError(
-            "Found numerator larger than denominator while calculating binomial uncertainty"
-        )
+        msg = "Found numerator larger than denominator while calculating binomial uncertainty"
+        raise ValueError(msg)
     interval_min = stats.beta.ppf((1 - coverage) / 2, num, denom - num + 1)
     interval_max = stats.beta.ppf((1 + coverage) / 2, num + 1, denom - num)
     interval = np.stack((interval_min, interval_max))
@@ -159,7 +158,6 @@ def ratio_uncertainty(
     elif uncertainty_type == "efficiency":
         ratio_uncert = np.abs(clopper_pearson_interval(num, denom) - ratio)
     else:
-        raise TypeError(
-            f"'{uncertainty_type}' is an invalid option for uncertainty_type."
-        )
+        msg = f"'{uncertainty_type}' is an invalid option for uncertainty_type."  # type: ignore[unreachable]
+        raise TypeError(msg)
     return ratio_uncert

--- a/src/hist/namedhist.py
+++ b/src/hist/namedhist.py
@@ -8,8 +8,10 @@ import boost_histogram as bh
 import hist
 
 from . import interop
-from ._compat.typing import ArrayLike, Self
 from .basehist import BaseHist, IndexingExpr
+
+if typing.TYPE_CHECKING:
+    from ._compat.typing import ArrayLike, Self
 
 S = TypeVar("S", bound=bh.storage.Storage)
 
@@ -22,9 +24,8 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
 
         super().__init__(*args, **kwargs)
         if args and "" in self.axes.name:
-            raise RuntimeError(
-                f"Each axes in the {self.__class__.__name__} instance should have a name"
-            )
+            msg = f"Each axes in the {self.__class__.__name__} instance should have a name"
+            raise RuntimeError(msg)
 
     def project(self, *args: int | str) -> Self:
         """
@@ -34,9 +35,8 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
         if not args or all(isinstance(x, str) for x in args):
             return super().project(*args)
 
-        raise TypeError(
-            f"Only projections by names are supported for {self.__class__.__name__}"
-        )
+        msg = f"Only projections by names are supported for {self.__class__.__name__}"
+        raise TypeError(msg)
 
     # pylint: disable-next=arguments-differ
     def fill(  # type: ignore[override]
@@ -54,9 +54,8 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
         if kwargs and all(isinstance(k, str) for k in kwargs):
             return super().fill(weight=weight, sample=sample, threads=threads, **kwargs)
 
-        raise TypeError(
-            f"Only fill by names are supported for {self.__class__.__name__}"
-        )
+        msg = f"Only fill by names are supported for {self.__class__.__name__}"
+        raise TypeError(msg)
 
     # pylint: disable-next=arguments-differ
     def fill_flattened(  # type: ignore[override]
@@ -80,18 +79,20 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
         # structures for multi-dimensional hists that must first be unpacked
         if obj is not None:
             if kwargs:
-                raise TypeError(
+                msg = (
                     "Only explicit keyword arguments, or a single structured object is supported by "
                     "`fill_flattened`, but not both."
                 )
+                raise TypeError(msg)
 
             destructured = interop.destructure(obj)
             # Try to unpack the array, if it's valid to do so, i.e. is the Awkward Array a record array?
             if destructured is None:
-                raise TypeError(
+                msg = (
                     f"Only fill by names are supported for {self.__class__.__name__}. A single object was given to "
                     "`fill_flattened`, but it could not be destructed into name-array pairs."
                 )
+                raise TypeError(msg)
 
             # Result must be broadcast, so unpack and rebuild
             broadcast = interop.broadcast_and_flatten(
@@ -132,9 +133,8 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
             """
 
             if isinstance(index, dict) and any(isinstance(k, int) for k in index):
-                raise TypeError(
-                    f"Only access by names are supported for {self.__class__.__name__} in dictionary"
-                )
+                msg = f"Only access by names are supported for {self.__class__.__name__} in dictionary"
+                raise TypeError(msg)
 
             return super().__getitem__(index)
 
@@ -148,8 +148,7 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
         """
 
         if isinstance(index, dict) and any(isinstance(k, int) for k in index):
-            raise TypeError(
-                f"Only access by names are supported for {self.__class__.__name__} in dictionary"
-            )
+            msg = f"Only access by names are supported for {self.__class__.__name__} in dictionary"
+            raise TypeError(msg)
 
         return super().__setitem__(index, value)

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import inspect
 import sys
-from collections.abc import Callable, Iterable
-from typing import Any, Literal, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias
 
 import numpy as np
 
 import hist
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 try:
     import matplotlib.axes
@@ -73,7 +75,7 @@ def _expand_shortcuts(key: str) -> str:
 
 
 def _filter_dict(
-    __dict: dict[str, Any], prefix: str, *, ignore: set[str] | None = None
+    dict_: dict[str, Any], prefix: str, *, ignore: set[str] | None = None
 ) -> dict[str, Any]:
     """
     Keyword argument conversion: convert the kwargs to several independent args, pulling
@@ -81,14 +83,14 @@ def _filter_dict(
     """
 
     # If passed explicitly, use that
-    if f"{prefix}kw" in __dict:
-        res: dict[str, Any] = __dict.pop(f"{prefix}kw")
+    if f"{prefix}kw" in dict_:
+        res: dict[str, Any] = dict_.pop(f"{prefix}kw")
         return {_expand_shortcuts(k): v for k, v in res.items()}
 
     ignore_set: set[str] = ignore or set()
     return {
-        _expand_shortcuts(key[len(prefix) :]): __dict.pop(key)
-        for key in list(__dict)
+        _expand_shortcuts(key[len(prefix) :]): dict_.pop(key)
+        for key in list(dict_)
         if key.startswith(prefix) and key not in ignore_set
     }
 
@@ -113,7 +115,7 @@ def _expr_to_lambda(expr: str) -> Callable[..., Any]:
         tokval = x[1]
         if toknum != NAME:
             continue
-        if ix > 0 and g[ix - 1][1] in {"."}:
+        if ix > 0 and g[ix - 1][1] == ".":
             continue
         if ix < len(g) - 1 and g[ix + 1][1] in {".", "("}:
             continue
@@ -194,7 +196,8 @@ def _plot_keywords_wrapper(ax: matplotlib.axes.Axes, legend: bool | None) -> Non
         if ax.get_legend_handles_labels()[0]:
             ax.legend()
         else:
-            raise ValueError("No labels to legend")
+            msg = "No labels to legend"
+            raise ValueError(msg)
 
 
 def plot2d_full(
@@ -225,7 +228,8 @@ def plot2d_full(
     """
     # Type judgement
     if self.ndim != 2:
-        raise TypeError("Only 2D-histogram has plot2d_full")
+        msg = "Only 2D-histogram has plot2d_full"
+        raise TypeError(msg)
 
     if ax_dict is None:
         ax_dict = {}
@@ -237,7 +241,8 @@ def plot2d_full(
             top_ax = ax_dict["top_ax"]
             side_ax = ax_dict["side_ax"]
         except KeyError as err:
-            raise ValueError("All axes should be all given or none at all") from err
+            msg = "All axes should be all given or none at all"
+            raise ValueError(msg) from err
 
     else:
         fig = plt.gcf()
@@ -256,7 +261,8 @@ def plot2d_full(
 
     # judge whether some arguments left
     if kwargs:
-        raise ValueError(f"{set(kwargs)} not needed")
+        msg = f"{set(kwargs)} not needed"
+        raise ValueError(msg)
 
     # Plot: plot the 2d-histogram
 
@@ -296,10 +302,10 @@ def plot2d_full(
 
 
 def _construct_gaussian_callable(
-    __hist: hist.BaseHist[Any],
+    hist_: hist.BaseHist[Any],
 ) -> Callable[[np.typing.NDArray[Any]], np.typing.NDArray[Any]]:
-    x_values = __hist.axes[0].centers
-    hist_values = __hist.values()
+    x_values = hist_.axes[0].centers
+    hist_values = hist_.values()
 
     # gaussian with reasonable initial guesses for parameters
     constant = float(hist_values.max())
@@ -337,9 +343,8 @@ def _fit_callable_to_hist(
     """
     variances = histogram.variances()
     if variances is None:
-        raise RuntimeError(
-            "Cannot compute from a variance-less histogram, try a Weight storage"
-        )
+        msg = "Cannot compute from a variance-less histogram, try a Weight storage"
+        raise RuntimeError(msg)
     hist_uncert = np.sqrt(variances)
 
     # Infer best fit model parameters and covariance matrix
@@ -361,7 +366,7 @@ def _fit_callable_to_hist(
 
 
 def _plot_fit_result(
-    __hist: hist.BaseHist[Any],
+    hist_: hist.BaseHist[Any],
     model_values: np.typing.NDArray[Any],
     model_uncert: np.typing.NDArray[Any],
     ax: matplotlib.axes.Axes,
@@ -372,15 +377,14 @@ def _plot_fit_result(
     """
     Plot fit of model to histogram data
     """
-    x_values = __hist.axes[0].centers
-    variances = __hist.variances()
+    x_values = hist_.axes[0].centers
+    variances = hist_.variances()
     if variances is None:
-        raise RuntimeError(
-            "Cannot compute from a variance-less histogram, try a Weight storage"
-        )
+        msg = "Cannot compute from a variance-less histogram, try a Weight storage"
+        raise RuntimeError(msg)
     hist_uncert = np.sqrt(variances)
 
-    errorbars = ax.errorbar(x_values, __hist.values(), hist_uncert, **eb_kwargs)
+    errorbars = ax.errorbar(x_values, hist_.values(), hist_uncert, **eb_kwargs)
 
     # Ensure zorder draws data points above model
     line_zorder = errorbars[0].get_zorder() - 1
@@ -401,7 +405,7 @@ def _plot_fit_result(
 
 
 def plot_ratio_array(
-    __hist: hist.BaseHist[Any],
+    hist_: hist.BaseHist[Any],
     ratio: np.typing.NDArray[Any],
     ratio_uncert: np.typing.NDArray[Any],
     ax: matplotlib.axes.Axes,
@@ -429,9 +433,9 @@ def plot_ratio_array(
         the ratio values and their uncertainties.
 
     """
-    x_values = __hist.axes[0].edges[:-1]
-    left_edge = __hist.axes.edges[0][0]
-    right_edge = __hist.axes.edges[-1][-1]
+    x_values = hist_.axes[0].edges[:-1]
+    left_edge = hist_.axes.edges[0][0]
+    right_edge = hist_.axes.edges[-1][-1]
 
     # Set 0 and inf to nan to hide during plotting
     ratio[ratio == 0] = np.nan
@@ -505,14 +509,14 @@ def plot_ratio_array(
     ax.set_xlim(left_edge, right_edge)
     ax.set_ylim(bottom=ratio_ylim[0], top=ratio_ylim[1])
 
-    ax.set_xlabel(__hist.axes[0].label)
+    ax.set_xlabel(hist_.axes[0].label)
     ax.set_ylabel(kwargs.pop("ylabel", "Ratio"))
 
     return axis_artists
 
 
 def plot_pull_array(
-    __hist: hist.BaseHist[Any],
+    hist_: hist.BaseHist[Any],
     pulls: np.typing.NDArray[Any],
     ax: matplotlib.axes.Axes,
     bar_kwargs: dict[str, Any],
@@ -521,9 +525,9 @@ def plot_pull_array(
     """
     Plot a pull plot on the given axes
     """
-    x_values = __hist.axes[0].centers
-    left_edge = __hist.axes.edges[0][0]
-    right_edge = __hist.axes.edges[-1][-1]
+    x_values = hist_.axes[0].centers
+    left_edge = hist_.axes.edges[0][0]
+    right_edge = hist_.axes.edges[-1][-1]
 
     # Pull: plot the pulls using Matplotlib bar method
     width = (right_edge - left_edge) / len(pulls)
@@ -555,7 +559,7 @@ def plot_pull_array(
 
     ax.set_xlim(left_edge, right_edge)
 
-    ax.set_xlabel(__hist.axes[0].label)
+    ax.set_xlabel(hist_.axes[0].label)
     ax.set_ylabel("Pull")
 
     return PullArtists(bar_artists, patch_artists)
@@ -610,20 +614,19 @@ def _plot_ratiolike(
     from .intervals import ratio_uncertainty
 
     if self.ndim != 1:
-        raise TypeError(
-            f"Only 1D-histogram supports ratio plot, try projecting {self.__class__.__name__} to 1D"
-        )
+        msg = f"Only 1D-histogram supports ratio plot, try projecting {self.__class__.__name__} to 1D"
+        raise TypeError(msg)
     if isinstance(other, hist.hist.Hist) and other.ndim != 1:
-        raise TypeError(
-            f"Only 1D-histogram supports ratio plot, try projecting other={other.__class__.__name__} to 1D"
-        )
+        msg = f"Only 1D-histogram supports ratio plot, try projecting other={other.__class__.__name__} to 1D"
+        raise TypeError(msg)
 
     if ax_dict:
         try:
             main_ax = ax_dict["main_ax"]
             subplot_ax = ax_dict[f"{view}_ax"]
         except KeyError as err:
-            raise ValueError("All axes should be all given or none at all") from err
+            msg = "All axes should be all given or none at all"
+            raise ValueError(msg) from err
     else:
         fig = plt.gcf()
         grid = fig.add_gridspec(2, 1, hspace=0, height_ratios=[3, 1])
@@ -666,7 +669,8 @@ def _plot_ratiolike(
 
     # Judge whether some arguments are left
     if kwargs:
-        raise ValueError(f"{set(kwargs)}' not needed")
+        msg = f"{set(kwargs)}' not needed"
+        raise ValueError(msg)
 
     main_ax.set_ylabel(fp_kwargs["label"])
 
@@ -789,7 +793,8 @@ def plot_stack(
     **kwargs: Any,
 ) -> Any:
     if self[0].ndim != 1:
-        raise NotImplementedError("Please project to 1D before calling plot")
+        msg = "Please project to 1D before calling plot"
+        raise NotImplementedError(msg)
 
     if "label" not in kwargs and all(h.name is not None for h in self):
         kwargs["label"] = [h.name for h in self]

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
-import boost_histogram as bh
-import numpy as np
-
 from . import axis, storage
-from .axis import AxisProtocol
-from .axis.transform import AxisTransform
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    import boost_histogram as bh
+    import numpy as np
+
+    from .axis import AxisProtocol
+    from .axis.transform import AxisTransform
     from .basehist import BaseHist
 
 

--- a/src/hist/stack.py
+++ b/src/hist/stack.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 import copy
 import typing
-from collections.abc import Iterator
 from typing import Any, Generic, TypeVar
 
 import boost_histogram as bh
 import histoprint
-import numpy as np
 
-from ._compat.typing import Self
-from .axestuple import NamedAxesTuple
 from .basehist import BaseHist
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import matplotlib as mpl
+    import numpy as np
+
+    from ._compat.typing import Self
+    from .axestuple import NamedAxesTuple
 
 
 __all__ = ("Stack",)
@@ -35,15 +37,18 @@ class Stack(Generic[S]):
         self._stack = list(args)
 
         if not args:
-            raise ValueError("There should be histograms in the Stack")
+            msg = "There should be histograms in the Stack"
+            raise ValueError(msg)
 
         if not all(isinstance(a, BaseHist) for a in args):
-            raise ValueError("There should be only histograms in Stack")
+            msg = "There should be only histograms in Stack"
+            raise ValueError(msg)
 
         first_axes = args[0].axes
         for a in args[1:]:
             if first_axes != a.axes:
-                raise ValueError("The Histogram axes don't match")
+                msg = "The Histogram axes don't match"
+                raise ValueError(msg)
 
     __hash__ = None  # type: ignore[assignment]
 
@@ -76,7 +81,8 @@ class Stack(Generic[S]):
             if h.name == name:
                 return n
 
-        raise IndexError(f"Name not found: {name}")
+        msg = f"Name not found: {name}"
+        raise IndexError(msg)
 
     @typing.overload
     def __getitem__(self, val: int | str) -> BaseHist[S]: ...
@@ -100,11 +106,13 @@ class Stack(Generic[S]):
         Set a histogram in the Stack. Checks the axes of the histogram, they must match.
         """
         if not isinstance(value, BaseHist):
-            raise ValueError("The value should be a histogram")
+            msg = "The value should be a histogram"  # type: ignore[unreachable]
+            raise TypeError(msg)
         if isinstance(key, str):
             key = self._get_index(key)
-        if not value.axes == self._stack[key].axes:
-            raise ValueError("The histogram axes don't match")
+        if value.axes != self._stack[key].axes:
+            msg = "The histogram axes don't match"
+            raise ValueError(msg)
 
         self._stack[key] = value
 
@@ -119,7 +127,7 @@ class Stack(Generic[S]):
         h = repr(self[0]) if len(self) else "Empty stack"
         return f"{self.__class__.__name__}<({names}) of {h}>"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Stack):
             return False
         return self._stack == other._stack

--- a/src/hist/svgplots.py
+++ b/src/hist/svgplots.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from boost_histogram.axis import Axis
-
-import hist
 
 from .svgutils import (
     SupportsStr,
@@ -21,6 +17,13 @@ from .svgutils import (
     svg,
     text,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from boost_histogram.axis import Axis
+
+    import hist
 
 
 def _desc_hist(h: hist.BaseHist[Any]) -> str:

--- a/src/hist/svgutils.py
+++ b/src/hist/svgutils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from ._compat.typing import Self
+if TYPE_CHECKING:
+    from ._compat.typing import Self
 
 
 class SupportsStr(Protocol):

--- a/src/hist/version.pyi
+++ b/src/hist/version.pyi
@@ -1,4 +1,2 @@
-from __future__ import annotations
-
 version: str
 version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]


### PR DESCRIPTION
Using prompt:

> Run `sp-ruff-checks` and add each check in the unselected category, checking with `prek -a ruff-check` and fix or ignore as needed.

Using current development branch of `scientific-python/cookie`'s `sp-ruff-checks`.

:robot: Assisted-by: OpenCode:Kimi-K2.6
