### PR TITLE
chore: ignore a CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,7 @@ banner_slides.pdf
 # Lock files
 uv.lock
 *pylock
+
+# Symlink to AGENTS.md
+CLAUDE.md
+.claude/


### PR DESCRIPTION
Only Claude Code doesn't follow the standard.
