### PR TITLE
refactor(interop): stop at first MRO match and dedupe broadcast helper

### DIFF
--- a/src/hist/interop.py
+++ b/src/hist/interop.py
@@ -49,12 +49,12 @@ def find_histogram_modules(
         try:
             yield arg._histogram_module_
         except AttributeError:
-            # Find class exactly, or check subclasses
+            # Find class exactly, or check subclasses, stopping at the first
+            # registered base in the MRO.
             for cls in type(arg).__mro__:
-                try:
+                if cls in _histogram_modules:
                     yield _histogram_modules[cls]
-                except KeyError:
-                    continue
+                    break
 
 
 def destructure(obj: Any) -> dict[str, Any] | None:
@@ -91,6 +91,22 @@ def broadcast_and_flatten(
     raise TypeError(msg)
 
 
+def _numpy_broadcast_and_flatten(
+    args: Sequence[Any],
+) -> tuple[np.typing.NDArray[Any], ...]:
+    """Broadcast and ravel args via NumPy, or ``NotImplemented`` if any arg
+    cannot be interpreted as a NumPy array."""
+    arrays = []
+    for arg in args:
+        # If we can't interpret this argument, it's not NumPy-friendly!
+        try:
+            arrays.append(np.asarray(arg))
+        except (TypeError, ValueError):
+            return NotImplemented  # type: ignore[no-any-return]
+
+    return tuple(np.ravel(x) for x in np.broadcast_arrays(*arrays))
+
+
 @histogram_module_for(np.ndarray)
 class NumpyHistogramModule:
     @staticmethod
@@ -104,15 +120,7 @@ class NumpyHistogramModule:
     def broadcast_and_flatten(
         args: Sequence[np.typing.NDArray[Any] | ArrayLike],
     ) -> tuple[np.typing.NDArray[Any], ...]:
-        arrays = []
-        for arg in args:
-            # If we can't interpret this argument, it's not NumPy-friendly!
-            try:
-                arrays.append(np.asarray(arg))
-            except (TypeError, ValueError):
-                return NotImplemented  # type: ignore[no-any-return]
-
-        return tuple(np.ravel(x) for x in np.broadcast_arrays(*arrays))
+        return _numpy_broadcast_and_flatten(args)
 
 
 try:
@@ -131,12 +139,4 @@ else:
         def broadcast_and_flatten(
             args: Sequence[pd.Series[Any] | ArrayLike],
         ) -> tuple[np.typing.NDArray[Any], ...]:
-            arrays = []
-            for arg in args:
-                # If we can't interpret this argument, it's not NumPy-friendly!
-                try:
-                    arrays.append(np.asarray(arg))
-                except (TypeError, ValueError):
-                    return NotImplemented  # type: ignore[no-any-return]
-
-            return tuple(np.ravel(x) for x in np.broadcast_arrays(*arrays))
+            return _numpy_broadcast_and_flatten(args)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #690 (items 3 and 6).

### 3. Stop at the first registered MRO base
`find_histogram_modules` walked the entire `__mro__` with no `break`, so a registered module could be yielded multiple times for one argument. Consumers only use the first, so this was harmless, but it's a latent trap. Now stops at the first registered base.

### 6. Dedupe `broadcast_and_flatten`
`NumpyHistogramModule.broadcast_and_flatten` and `PandasHistogramModule.broadcast_and_flatten` were byte-identical. Extracted a shared module-level `_numpy_broadcast_and_flatten` helper.

`test_interop.py` passes; mypy (strict) passes.
