### PR TITLE
perf(basehist): reuse weight sum in profile; avoid mutable default storage

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -257,8 +257,10 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         axes: Sequence[str | AxisProtocol],
         *,
         weight: str | None = None,
-        storage: hist.storage.Storage = hist.storage.Double(),  # noqa: B008
+        storage: hist.storage.Storage | None = None,
     ) -> Self:
+        if storage is None:
+            storage = hist.storage.Double()
         axes_list: list[Any] = []
         for ax in axes:
             if isinstance(ax, str):
@@ -584,12 +586,12 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         num = np.tensordot(values, centers, ([iaxis], [0]))
         num_err = np.sqrt(np.tensordot(variances, centers**2, ([iaxis], [0])))
 
-        den = np.sum(values, axis=iaxis)
+        # The denominator is the same sum of weights as ``count``.
         den_err = np.sqrt(np.sum(variances, axis=iaxis))
 
         with np.errstate(invalid="ignore"):
-            new_values = num / den
-            new_variances = (num_err / den) ** 2 - (den_err * num / den**2) ** 2
+            new_values = num / count
+            new_variances = (num_err / count) ** 2 - (den_err * num / count**2) ** 2
 
         retval = self.__class__(*axes, storage=hist.storage.Mean())
         retval[...] = np.stack([count, new_values, count * new_variances], axis=-1)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #690 (items 5 and 7).

### 5. Reuse the weight sum in `profile`
`profile` computed `np.sum(values, axis=iaxis)` twice — once as `count`, once as `den` — to the same value. Dropped the duplicate and use `count` throughout.

### 7. No mutable default storage in `from_columns`
`from_columns` used a shared module-level `hist.storage.Double()` instance as a default argument (suppressed with `noqa: B008`). Switched to `storage: ... | None = None` with an internal default, removing the suppression.

`test_profile.py` + `test_general.py` pass; mypy (strict) passes.
