### PR TITLE
chore: expose hist.at and document Stack name-slice semantics

### DIFF
--- a/src/hist/__init__.py
+++ b/src/hist/__init__.py
@@ -14,6 +14,7 @@ from .hist import Hist
 from .namedhist import NamedHist
 from .stack import Stack
 from .tag import (
+    at,
     loc,
     overflow,
     rebin,
@@ -34,6 +35,7 @@ __all__ = (
     "Stack",
     "__version__",
     "accumulators",
+    "at",
     "axis",
     "loc",
     "new",

--- a/src/hist/stack.py
+++ b/src/hist/stack.py
@@ -91,6 +91,13 @@ class Stack(Generic[S]):
     def __getitem__(self, val: slice) -> Self: ...
 
     def __getitem__(self, val: int | slice | str) -> BaseHist[S] | Self:
+        """
+        Index the Stack by position or by histogram name.
+
+        Slices follow normal Python (half-open) semantics, so a slice stop
+        given as a name is *exclusive*: ``stack["a":"c"]`` yields the
+        histograms from ``"a"`` up to but not including ``"c"``.
+        """
         if isinstance(val, str):
             val = self._get_index(val)
         if isinstance(val, slice):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #690 (items 8 and 11).

### 11. Expose `hist.at`
`hist.tag.__all__` lists `at`, `Locator`, and `Slicer`, but the top-level package only re-exported `loc`/`overflow`/`rebin`/`sum`/`underflow`. Added `at` to the top-level imports and `__all__` — it's the same category of user-facing tag as `loc`. `Locator`/`Slicer` are left out as internal base classes (happy to add them too if you'd prefer full parity).

### 8. Document `Stack` name-slice semantics
`Stack.__getitem__` resolves a string slice stop to its index and then slices with normal (half-open) Python semantics, so `stack["a":"c"]` excludes `"c"`. Documented this in the method docstring rather than silently changing the behavior.

`test_stacks.py` passes; mypy (strict) passes; `hist.at` imports.
