### PR TITLE
ci: fix concurrency group expression (single -> double braces)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   FORCE_COLOR: 3
 
 concurrency:
-  group: ${ github.workflow }-${ github.ref }
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

### Problem
`ci.yml` set the concurrency group with **single-brace** interpolation:

```yaml
concurrency:
  group: ${ github.workflow }-${ github.ref }
  cancel-in-progress: true
```

GitHub Actions only evaluates `${{ ... }}` expressions. With single braces the value is a **literal constant string** (`${ github.workflow }-${ github.ref }`), identical for every run. Combined with `cancel-in-progress: true`, all CI runs across all branches and PRs land in one global concurrency group, so **each new push cancels the in-flight CI run of every other open PR**.

This is exactly what happened when several PRs were pushed in quick succession — the runs cancelled each other mid-test (showing up as cancelled `Check Python` jobs and a failed `pass` gate), even though the code was fine.

### Fix
Use the correct `${{ ... }}` syntax, matching `cd.yml`, so the group is per-workflow/per-ref as intended:

```yaml
  group: ${{ github.workflow }}-${{ github.ref }}
```

Now a new push only cancels superseded runs of the *same* ref.
