### PR TITLE
fix(plot): take sqrt for gaussian fit sigma initial guess

### DIFF
--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -310,7 +310,8 @@ def _construct_gaussian_callable(
     # gaussian with reasonable initial guesses for parameters
     constant = float(hist_values.max())
     mean = (hist_values * x_values).sum() / hist_values.sum()
-    sigma = (hist_values * np.square(x_values - mean)).sum() / hist_values.sum()
+    variance = (hist_values * np.square(x_values - mean)).sum() / hist_values.sum()
+    sigma = np.sqrt(variance)
 
     # gauss is a closure that will get evaluated in _fit_callable_to_hist
     def gauss(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -922,3 +922,26 @@ def test_plot_ratio_misalignment():
     plot_ratio_array(h, ratio, ratio_uncert, ax=Ax(), uncert_draw_type="line")
 
     assert np.allclose(captured["x"], h.axes[0].edges[:-1])
+
+
+def test_construct_gaussian_callable_sigma():
+    # Regression test for issue #483: the initial-guess sigma must be a
+    # standard deviation, not the variance (np.sqrt was missing).
+    from hist.plot import _construct_gaussian_callable
+
+    true_mean = 5.0
+    true_std = 2.0
+
+    h = Hist(axis.Regular(200, -10, 20))
+    centers = h.axes[0].centers
+    width = h.axes[0].edges[1] - h.axes[0].edges[0]
+    density = np.exp(-0.5 * ((centers - true_mean) / true_std) ** 2)
+    h[...] = density * width * 1e5
+
+    gauss = _construct_gaussian_callable(h)
+    # Defaults are (constant, mean, sigma)
+    _constant, mean, sigma = gauss.__defaults__
+
+    assert mean == pytest.approx(true_mean, abs=0.05)
+    # Before the fix this returned the variance (~true_std**2 == 4.0)
+    assert sigma == pytest.approx(true_std, rel=0.05)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #483.

`_construct_gaussian_callable` assigned the **variance** to `sigma`, and the `gauss` closure then used `2 * np.square(sigma)` — effectively squaring the variance. The initial-guess sigma is now `np.sqrt(variance)`, a true standard deviation.

**Test:** `tests/test_plot.py::test_construct_gaussian_callable_sigma` builds a histogram from a known Gaussian (std 2.0), calls `_construct_gaussian_callable` directly (no `--mpl` needed), and asserts the recovered sigma ≈ 2.0 (was ≈ 4.0). Confirmed failing before, passing after.