### PR TITLE
fix(basehist): normalize negative integer indices

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -460,8 +460,8 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             return [self._loc_shortcut(each) for each in x]
         if isinstance(x, slice):
             return slice(
-                self._loc_shortcut(x.start),
-                self._loc_shortcut(x.stop),
+                self._loc_shortcut(x.start, ax_id),
+                self._loc_shortcut(x.stop, ax_id),
                 self._step_shortcut(x.step),
             )
         if isinstance(x, complex):
@@ -471,6 +471,16 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
             return bh.loc(x.imag, int(x.real))
         if isinstance(x, str):
             return bh.loc(x)
+        # Normalize plain negative integers relative to the axis length, like
+        # Python/NumPy indexing. Complex (by-value) indices, bools, and UHI tags
+        # are intentionally left untouched (#559).
+        if (
+            ax_id is not None
+            and isinstance(x, (int, np.integer))
+            and not isinstance(x, bool)
+            and x < 0
+        ):
+            return int(x) + len(self.axes[ax_id])
         return x
 
     @staticmethod

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -421,6 +421,37 @@ def test_general_index_access():
         h[0:10:20j, 0:5:10j, "hello", False, 5]
 
 
+def test_negative_index_access():
+    """
+    Negative plain-int indices and slice bounds should be normalized relative
+    to the number of bins on the axis, like Python/NumPy semantics (#559).
+    """
+
+    h = Hist(axis.Regular(10, 0, 10, name="x")).fill(np.linspace(0, 9, 10, dtype=float))
+
+    # Bare integer index
+    assert h[-1] == h[9]
+    assert h[-2] == h[8]
+
+    # Slice bounds (positional)
+    assert h[1:-2] == h[1:8]
+    assert h[-3:-1] == h[7:9]
+    assert h[-3:] == h[7:]
+    assert h[:-2] == h[:8]
+
+    # Named / dict indexing goes through the same path
+    assert h[{"x": -2}] == h[{"x": 8}]
+    assert h[{"x": slice(1, -2)}] == h[{"x": slice(1, 8)}]
+
+    # Two-axis case to confirm per-axis normalization uses the right length
+    h2 = Hist(
+        axis.Regular(10, 0, 10, name="x"),
+        axis.Regular(4, 0, 4, name="y"),
+    )
+    assert h2[1:-2, :].axes[0].size == h2[1:8, :].axes[0].size
+    assert h2[:, -1] == h2[:, 3]
+
+
 class TestGeneralStorageProxy:
     """
         Test general storage proxy suite -- whether Hist storage proxy \


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #559.

Negative slice bounds raised `ValueError: begin < end required` (e.g. `h[1:-2]`) because plain negative ints were passed straight to boost-histogram, which does not apply NumPy-style negative indexing. `_loc_shortcut` now threads the per-axis id through to slice bounds and normalizes plain negative `int`/`np.integer` against the axis length. `bool`, `complex` (by-value / `loc`), `None`, rebin `step`, etc. are untouched.

**Test:** `tests/test_general.py::test_negative_index_access` — `h[-1]==h[9]`, `h[1:-2]==h[1:8]`, `h[-3:-1]==h[7:9]`, dict-form equivalents, and a two-axis per-axis-length case. Confirmed failing before, passing after.