### PR TITLE
fix(plot): align main axis x-range with user-supplied axes in ratio/pull plots

### DIFF
--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -757,6 +757,12 @@ def _plot_ratiolike(
                 self, pulls, ax=subplot_ax, bar_kwargs=bar_kwargs, pp_kwargs=pp_kwargs
             )
 
+    # Match the main axis x-range to the bin edges so it lines up with the
+    # subplot. The subplot pins its own xlim; without this the two only stayed
+    # aligned via sharex in the auto-created branch, leaving user-supplied
+    # ax_dict axes misaligned (see #659).
+    main_ax.set_xlim(self.axes.edges[0][0], self.axes.edges[-1][-1])
+
     if main_ax.get_legend_handles_labels()[0]:  # Don't plot an empty legend
         main_ax.legend(loc=rp_kwargs["legend_loc"])
 

--- a/src/hist/plot.py
+++ b/src/hist/plot.py
@@ -758,6 +758,12 @@ def _plot_ratiolike(
                 self, pulls, ax=subplot_ax, bar_kwargs=bar_kwargs, pp_kwargs=pp_kwargs
             )
 
+    # Match the main axis x-range to the bin edges so it lines up with the
+    # subplot. The subplot pins its own xlim; without this the two only stayed
+    # aligned via sharex in the auto-created branch, leaving user-supplied
+    # ax_dict axes misaligned (see #659).
+    main_ax.set_xlim(self.axes.edges[0][0], self.axes.edges[-1][-1])
+
     if main_ax.get_legend_handles_labels()[0]:  # Don't plot an empty legend
         main_ax.legend(loc=rp_kwargs["legend_loc"])
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -922,3 +922,62 @@ def test_plot_ratio_misalignment():
     plot_ratio_array(h, ratio, ratio_uncert, ax=Ax(), uncert_draw_type="line")
 
     assert np.allclose(captured["x"], h.axes[0].edges[:-1])
+
+
+@pytest.mark.parametrize("kind", ["int", "reg"])
+def test_plot_ratio_ax_dict_alignment(kind):
+    """
+    The main and subplot axes must line up identically whether the axes are
+    auto-created or supplied via ax_dict, for both Integer and Regular axes (#659).
+    """
+
+    value_ax = (
+        axis.Integer(0, 10, name="v")
+        if kind == "int"
+        else axis.Regular(10, 0, 10, name="v")
+    )
+    h = Hist(axis.StrCategory(["a", "b"], name="cat"), value_ax)
+    rng = np.random.default_rng(42)
+    h.fill(cat="a", v=rng.integers(0, 10, size=200))
+    h.fill(cat="b", v=rng.integers(0, 10, size=200))
+    num = h[{"cat": "a"}]
+    den = h[{"cat": "b"}]
+
+    def ratio_point_x(subplot_ax):
+        # The errorbar data line carries one x per bin; the central reference
+        # line (axhline) carries only the two axis endpoints.
+        per_bin = [
+            np.asarray(line.get_xdata())
+            for line in subplot_ax.get_lines()
+            if np.asarray(line.get_xdata()).size == num.axes[0].size
+        ]
+        assert per_bin, "ratio points not found"
+        return per_bin[0]
+
+    def make(own):
+        fig = plt.figure()
+        if own:
+            grid = fig.add_gridspec(2, 1, hspace=0, height_ratios=[3, 1])
+            main_ax = fig.add_subplot(grid[0])
+            sub_ax = fig.add_subplot(grid[1])
+            num.plot_ratio(den, ax_dict={"main_ax": main_ax, "ratio_ax": sub_ax})
+        else:
+            num.plot_ratio(den)
+            main_ax, sub_ax = fig.axes[0], fig.axes[1]
+        result = (
+            main_ax.get_xlim(),
+            sub_ax.get_xlim(),
+            ratio_point_x(sub_ax),
+        )
+        plt.close(fig)
+        return result
+
+    auto_main_xlim, auto_sub_xlim, auto_x = make(own=False)
+    own_main_xlim, own_sub_xlim, own_x = make(own=True)
+
+    # Within each branch, main and subplot share the same x-range.
+    assert auto_main_xlim == auto_sub_xlim
+    assert own_main_xlim == own_sub_xlim
+    # And the two branches agree with each other.
+    assert auto_main_xlim == own_main_xlim
+    assert np.allclose(auto_x, own_x)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -945,3 +945,62 @@ def test_construct_gaussian_callable_sigma():
     assert mean == pytest.approx(true_mean, abs=0.05)
     # Before the fix this returned the variance (~true_std**2 == 4.0)
     assert sigma == pytest.approx(true_std, rel=0.05)
+
+
+@pytest.mark.parametrize("kind", ["int", "reg"])
+def test_plot_ratio_ax_dict_alignment(kind):
+    """
+    The main and subplot axes must line up identically whether the axes are
+    auto-created or supplied via ax_dict, for both Integer and Regular axes (#659).
+    """
+
+    value_ax = (
+        axis.Integer(0, 10, name="v")
+        if kind == "int"
+        else axis.Regular(10, 0, 10, name="v")
+    )
+    h = Hist(axis.StrCategory(["a", "b"], name="cat"), value_ax)
+    rng = np.random.default_rng(42)
+    h.fill(cat="a", v=rng.integers(0, 10, size=200))
+    h.fill(cat="b", v=rng.integers(0, 10, size=200))
+    num = h[{"cat": "a"}]
+    den = h[{"cat": "b"}]
+
+    def ratio_point_x(subplot_ax):
+        # The errorbar data line carries one x per bin; the central reference
+        # line (axhline) carries only the two axis endpoints.
+        per_bin = [
+            np.asarray(line.get_xdata())
+            for line in subplot_ax.get_lines()
+            if np.asarray(line.get_xdata()).size == num.axes[0].size
+        ]
+        assert per_bin, "ratio points not found"
+        return per_bin[0]
+
+    def make(own):
+        fig = plt.figure()
+        if own:
+            grid = fig.add_gridspec(2, 1, hspace=0, height_ratios=[3, 1])
+            main_ax = fig.add_subplot(grid[0])
+            sub_ax = fig.add_subplot(grid[1])
+            num.plot_ratio(den, ax_dict={"main_ax": main_ax, "ratio_ax": sub_ax})
+        else:
+            num.plot_ratio(den)
+            main_ax, sub_ax = fig.axes[0], fig.axes[1]
+        result = (
+            main_ax.get_xlim(),
+            sub_ax.get_xlim(),
+            ratio_point_x(sub_ax),
+        )
+        plt.close(fig)
+        return result
+
+    auto_main_xlim, auto_sub_xlim, auto_x = make(own=False)
+    own_main_xlim, own_sub_xlim, own_x = make(own=True)
+
+    # Within each branch, main and subplot share the same x-range.
+    assert auto_main_xlim == auto_sub_xlim
+    assert own_main_xlim == own_sub_xlim
+    # And the two branches agree with each other.
+    assert auto_main_xlim == own_main_xlim
+    assert np.allclose(auto_x, own_x)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #659.

In `_plot_ratiolike`, the main axis was pinned to the bin-edge range only via `sharex` in the auto-created-subplot branch. When the user supplied their own axes through `ax_dict` there was no `sharex`, so the main axis kept matplotlib's autoscaled (5% margin) limits while the subplot was clamped to the edges — the histogram and the ratio/pull points failed to line up. The fix sets `main_ax.set_xlim(...)` to the bin edges in both branches (the auto branch value is unchanged, so existing `--mpl` baselines stay valid).

**Test:** `tests/test_plot.py::test_plot_ratio_ax_dict_alignment` (parametrized int/reg) asserts main/subplot xlim agree and the with/without-`ax_dict` cases match — numeric only, no image comparison.

**Left for review:** the separate question of ratio markers at left-edge vs center for Regular axes (#637/#655) is consistent across both branches here, so it's out of scope for this inconsistency fix.