### PR TITLE
fix(quick_construct): preserve histogram subclass type through construction

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -59,7 +59,7 @@ def _proc_kw_for_lw(kwargs: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def process_mistaken_quick_construct(
-    axes: Sequence[AxisTypes | hist.quick_construct.ConstructProxy],
+    axes: Sequence[AxisTypes | hist.quick_construct.ConstructProxy[Any]],
 ) -> Generator[AxisTypes, None, None]:
     for ax in axes:
         if isinstance(ax, hist.quick_construct.ConstructProxy):

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -1,21 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from . import axis, storage
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-    import boost_histogram as bh
     import numpy as np
 
     from .axis import AxisProtocol
     from .axis.transform import AxisTransform
     from .basehist import BaseHist
 
+# Carries the originating histogram class (Hist, NamedHist, or a user subclass)
+# through the construction chain so storage finalizers return the real subclass.
+H = TypeVar("H", bound="BaseHist[Any]")
 
-class QuickConstruct:
+
+class QuickConstruct(Generic[H]):
     """
     Create a quick construct instance. This is the "base" quick constructor; it will
     always require at least one axes to be added before allowing a storage or fill to be performed.
@@ -30,7 +33,7 @@ class QuickConstruct:
         inside = ", ".join(repr(ax) for ax in self.axes)
         return f"{self.__class__.__name__}({self.hist_class.__name__}, {inside})"
 
-    def __init__(self, hist_class: type[BaseHist[Any]], *axes: AxisProtocol) -> None:
+    def __init__(self, hist_class: type[H], *axes: AxisProtocol) -> None:
         self.hist_class = hist_class
         self.axes = axes
 
@@ -50,7 +53,7 @@ class QuickConstruct:
         circular: bool = False,
         transform: AxisTransform | None = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -83,7 +86,7 @@ class QuickConstruct:
         label: str = "",
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -109,7 +112,7 @@ class QuickConstruct:
         label: str = "",
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -136,7 +139,7 @@ class QuickConstruct:
         power: float,
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -164,7 +167,7 @@ class QuickConstruct:
         inverse: Callable[[float], float],
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -186,7 +189,7 @@ class QuickConstruct:
         label: str = "",
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -213,7 +216,7 @@ class QuickConstruct:
         growth: bool = False,
         circular: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -247,7 +250,7 @@ class QuickConstruct:
         growth: bool = False,
         circular: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -277,7 +280,7 @@ class QuickConstruct:
         metadata: Any = None,
         growth: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -302,7 +305,7 @@ class QuickConstruct:
         metadata: Any = None,
         growth: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -319,7 +322,7 @@ class QuickConstruct:
     StrCategory = StrCat
 
 
-class ConstructProxy(QuickConstruct):
+class ConstructProxy(QuickConstruct[H]):
     __slots__ = ()
 
     def Double(
@@ -329,7 +332,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Double]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Double(),
@@ -346,7 +349,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Int64]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Int64(),
@@ -363,7 +366,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.AtomicInt64]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.AtomicInt64(),
@@ -380,7 +383,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Weight]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Weight(),
@@ -397,7 +400,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Mean]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Mean(),
@@ -414,7 +417,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.WeightedMean]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.WeightedMean(),
@@ -431,7 +434,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Unlimited]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Unlimited(),
@@ -452,7 +455,7 @@ class ConstructProxy(QuickConstruct):
             data: np.typing.NDArray[Any] | None = None,
             label: str | None = None,
             name: str | None = None,
-        ) -> BaseHist[bh.storage.MultiCell]:
+        ) -> H:
             return self.hist_class(
                 *self.axes,
                 storage=storage.MultiCell(nelem),
@@ -465,5 +468,5 @@ class ConstructProxy(QuickConstruct):
 
 class MetaConstructor(type):
     @property
-    def new(cls: type[BaseHist[Any]]) -> QuickConstruct:  # type: ignore[misc]
+    def new(cls: type[H]) -> QuickConstruct[H]:  # type: ignore[misc]
         return QuickConstruct(cls)

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
 from . import axis, storage
 
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from .axis import AxisProtocol
     from .axis.transform import AxisTransform
     from .basehist import BaseHist
+    from .hist import Hist
+    from .namedhist import NamedHist
 
 # Carries the originating histogram class (Hist, NamedHist, or a user subclass)
 # through the construction chain so storage finalizers return the real subclass.
@@ -325,6 +327,38 @@ class QuickConstruct(Generic[H]):
 class ConstructProxy(QuickConstruct[H]):
     __slots__ = ()
 
+    # Each finalizer has self-type overloads that select the storage-typed
+    # return (e.g. Hist[storage.Double]) for the known classes. Python typing
+    # has no higher-kinded types, so user subclasses take the fallback, which
+    # keeps the subclass but not the storage type.
+
+    @overload
+    def Double(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.Double]: ...
+    @overload
+    def Double(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.Double]: ...
+    @overload
+    def Double(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def Double(
         self,
         *,
@@ -332,7 +366,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.Double(),
@@ -342,6 +376,33 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def Int64(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.Int64]: ...
+    @overload
+    def Int64(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.Int64]: ...
+    @overload
+    def Int64(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def Int64(
         self,
         *,
@@ -349,7 +410,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.Int64(),
@@ -359,6 +420,33 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def AtomicInt64(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.AtomicInt64]: ...
+    @overload
+    def AtomicInt64(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.AtomicInt64]: ...
+    @overload
+    def AtomicInt64(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def AtomicInt64(
         self,
         *,
@@ -366,7 +454,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.AtomicInt64(),
@@ -376,6 +464,33 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def Weight(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.Weight]: ...
+    @overload
+    def Weight(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.Weight]: ...
+    @overload
+    def Weight(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def Weight(
         self,
         *,
@@ -383,7 +498,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.Weight(),
@@ -393,6 +508,33 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def Mean(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.Mean]: ...
+    @overload
+    def Mean(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.Mean]: ...
+    @overload
+    def Mean(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def Mean(
         self,
         *,
@@ -400,7 +542,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.Mean(),
@@ -410,6 +552,33 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def WeightedMean(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.WeightedMean]: ...
+    @overload
+    def WeightedMean(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.WeightedMean]: ...
+    @overload
+    def WeightedMean(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def WeightedMean(
         self,
         *,
@@ -417,7 +586,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.WeightedMean(),
@@ -427,6 +596,33 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def Unlimited(
+        self: ConstructProxy[NamedHist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.Unlimited]: ...
+    @overload
+    def Unlimited(
+        self: ConstructProxy[Hist[Any]],
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.Unlimited]: ...
+    @overload
+    def Unlimited(
+        self,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def Unlimited(
         self,
         *,
@@ -434,7 +630,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.Unlimited(),
@@ -444,6 +640,39 @@ class ConstructProxy(QuickConstruct[H]):
             name=name,
         )
 
+    @overload
+    def MultiCell(
+        self: ConstructProxy[NamedHist[Any]],
+        /,
+        nelem: int,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> NamedHist[storage.MultiCell]: ...
+    @overload
+    def MultiCell(
+        self: ConstructProxy[Hist[Any]],
+        /,
+        nelem: int,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> Hist[storage.MultiCell]: ...
+    @overload
+    def MultiCell(
+        self,
+        /,
+        nelem: int,
+        *,
+        metadata: Any = ...,
+        data: np.typing.NDArray[Any] | None = ...,
+        label: str | None = ...,
+        name: str | None = ...,
+    ) -> H: ...
     def MultiCell(
         self,
         /,
@@ -453,7 +682,7 @@ class ConstructProxy(QuickConstruct[H]):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> H:
+    ) -> Any:
         return self.hist_class(
             *self.axes,
             storage=storage.MultiCell(nelem),

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -1,21 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from . import axis, storage
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-    import boost_histogram as bh
     import numpy as np
 
     from .axis import AxisProtocol
     from .axis.transform import AxisTransform
     from .basehist import BaseHist
 
+# Carries the originating histogram class (Hist, NamedHist, or a user subclass)
+# through the construction chain so storage finalizers return the real subclass.
+H = TypeVar("H", bound="BaseHist[Any]")
 
-class QuickConstruct:
+
+class QuickConstruct(Generic[H]):
     """
     Create a quick construct instance. This is the "base" quick constructor; it will
     always require at least one axes to be added before allowing a storage or fill to be performed.
@@ -30,7 +33,7 @@ class QuickConstruct:
         inside = ", ".join(repr(ax) for ax in self.axes)
         return f"{self.__class__.__name__}({self.hist_class.__name__}, {inside})"
 
-    def __init__(self, hist_class: type[BaseHist[Any]], *axes: AxisProtocol) -> None:
+    def __init__(self, hist_class: type[H], *axes: AxisProtocol) -> None:
         self.hist_class = hist_class
         self.axes = axes
 
@@ -50,7 +53,7 @@ class QuickConstruct:
         circular: bool = False,
         transform: AxisTransform | None = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -83,7 +86,7 @@ class QuickConstruct:
         label: str = "",
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -109,7 +112,7 @@ class QuickConstruct:
         label: str = "",
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -136,7 +139,7 @@ class QuickConstruct:
         power: float,
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -164,7 +167,7 @@ class QuickConstruct:
         inverse: Callable[[float], float],
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -186,7 +189,7 @@ class QuickConstruct:
         label: str = "",
         metadata: Any = None,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -213,7 +216,7 @@ class QuickConstruct:
         growth: bool = False,
         circular: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -247,7 +250,7 @@ class QuickConstruct:
         growth: bool = False,
         circular: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -277,7 +280,7 @@ class QuickConstruct:
         metadata: Any = None,
         growth: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -302,7 +305,7 @@ class QuickConstruct:
         metadata: Any = None,
         growth: bool = False,
         __dict__: dict[str, Any] | None = None,
-    ) -> ConstructProxy:
+    ) -> ConstructProxy[H]:
         return ConstructProxy(
             self.hist_class,
             *self.axes,
@@ -319,7 +322,7 @@ class QuickConstruct:
     StrCategory = StrCat
 
 
-class ConstructProxy(QuickConstruct):
+class ConstructProxy(QuickConstruct[H]):
     __slots__ = ()
 
     def Double(
@@ -329,7 +332,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Double]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Double(),
@@ -346,7 +349,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Int64]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Int64(),
@@ -363,7 +366,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.AtomicInt64]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.AtomicInt64(),
@@ -380,7 +383,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Weight]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Weight(),
@@ -397,7 +400,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Mean]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Mean(),
@@ -414,7 +417,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.WeightedMean]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.WeightedMean(),
@@ -431,7 +434,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.Unlimited]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.Unlimited(),
@@ -450,7 +453,7 @@ class ConstructProxy(QuickConstruct):
         data: np.typing.NDArray[Any] | None = None,
         label: str | None = None,
         name: str | None = None,
-    ) -> BaseHist[bh.storage.MultiCell]:
+    ) -> H:
         return self.hist_class(
             *self.axes,
             storage=storage.MultiCell(nelem),
@@ -463,5 +466,5 @@ class ConstructProxy(QuickConstruct):
 
 class MetaConstructor(type):
     @property
-    def new(cls: type[BaseHist[Any]]) -> QuickConstruct:  # type: ignore[misc]
+    def new(cls: type[H]) -> QuickConstruct[H]:  # type: ignore[misc]
         return QuickConstruct(cls)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #675.

The quick-construct storage finalizers were annotated `-> BaseHist`, so `hist.Hist.new.Reg(...).Weight()` was statically typed as `BaseHist` and users had to cast. Two typing-only changes fix this; runtime behavior is unchanged.

1. `QuickConstruct`/`ConstructProxy` are now generic over `H = TypeVar(bound=BaseHist)`, captured from the originating class in `MetaConstructor.new`, so the finalizers return the real subclass (`Hist`, `NamedHist`, or a user subclass).
2. Each finalizer has self-type overloads for the known classes, so the storage parameter is also concrete: `Hist.new.Reg(...).Weight()` is `Hist[storage.Weight]`, and the same for `NamedHist`. Python typing has no higher-kinded types, so user subclasses (and the `hist.dask` classes) take the generic fallback: the subclass is kept, with `Any` storage.

**Verification:** `reveal_type` on mypy (strict) and pyright agrees: `Hist[Double]`, `NamedHist[Int64]`, `MyHist` for a user subclass (was `BaseHist[...]` for all). `prek -a` (strict mypy on `src/`) is clean. No permanent typing-test was added — the repo has no typing-test harness.
