### PR TITLE
feat: support boost-histogram 1.8, require 1.7+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   - id: mypy
     files: ^src
     args: []
-    additional_dependencies: ["numpy~=2.4.0", "matplotlib>=3.8", "boost-histogram~=1.7.1", "uhi~=1.0", "pandas-stubs>=2.0.1.230501"]
+    additional_dependencies: ["numpy~=2.4.0", "matplotlib>=3.8", "boost-histogram~=1.8.0", "uhi~=1.0", "pandas-stubs>=2.0.1.230501"]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ keywords = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "boost-histogram>=1.6,<1.8",
+    "boost-histogram>=1.7,<1.9",
     "histoprint>=2.2.0",
     'numpy>=1.21.3',
     'packaging>=23',

--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -286,12 +286,15 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         self.fill(**data_list, weight=weight_arr)  # type: ignore[arg-type]
         return self
 
-    def project(self, *args: int | str) -> Self:
+    def project(self, *args: int | str, flow: bool = True) -> Self:
         """
         Projection of axis idx.
         """
         int_args = [self._name_to_index(a) if isinstance(a, str) else a for a in args]
-        return super().project(*int_args)
+        if flow:
+            return super().project(*int_args)
+        # flow=False requires boost-histogram 1.8+
+        return super().project(*int_args, flow=False)
 
     @property
     def T(self) -> Self:

--- a/src/hist/namedhist.py
+++ b/src/hist/namedhist.py
@@ -27,13 +27,13 @@ class NamedHist(BaseHist[S], Generic[S], family=hist):
             msg = f"Each axes in the {self.__class__.__name__} instance should have a name"
             raise RuntimeError(msg)
 
-    def project(self, *args: int | str) -> Self:
+    def project(self, *args: int | str, flow: bool = True) -> Self:
         """
         Projection of axis idx.
         """
 
         if not args or all(isinstance(x, str) for x in args):
-            return super().project(*args)
+            return super().project(*args, flow=flow)
 
         msg = f"Only projections by names are supported for {self.__class__.__name__}"
         raise TypeError(msg)

--- a/src/hist/quick_construct.py
+++ b/src/hist/quick_construct.py
@@ -441,26 +441,24 @@ class ConstructProxy(QuickConstruct):
             name=name,
         )
 
-    if hasattr(storage, "MultiCell"):
-
-        def MultiCell(
-            self,
-            /,
-            nelem: int,
-            *,
-            metadata: Any = None,
-            data: np.typing.NDArray[Any] | None = None,
-            label: str | None = None,
-            name: str | None = None,
-        ) -> BaseHist[bh.storage.MultiCell]:
-            return self.hist_class(
-                *self.axes,
-                storage=storage.MultiCell(nelem),
-                metadata=metadata,
-                data=data,
-                label=label,
-                name=name,
-            )
+    def MultiCell(
+        self,
+        /,
+        nelem: int,
+        *,
+        metadata: Any = None,
+        data: np.typing.NDArray[Any] | None = None,
+        label: str | None = None,
+        name: str | None = None,
+    ) -> BaseHist[bh.storage.MultiCell]:
+        return self.hist_class(
+            *self.axes,
+            storage=storage.MultiCell(nelem),
+            metadata=metadata,
+            data=data,
+            label=label,
+            name=name,
+        )
 
 
 class MetaConstructor(type):

--- a/src/hist/storage.py
+++ b/src/hist/storage.py
@@ -5,6 +5,7 @@ from boost_histogram.storage import (
     Double,
     Int64,
     Mean,
+    MultiCell,
     Storage,
     Unlimited,
     Weight,
@@ -16,16 +17,9 @@ __all__ = [
     "Double",
     "Int64",
     "Mean",
+    "MultiCell",
     "Storage",
     "Unlimited",
     "Weight",
     "WeightedMean",
 ]
-
-try:
-    # pylint: disable-next=unused-import
-    from boost_histogram.storage import MultiCell
-
-    __all__ += ["MultiCell"]
-except ImportError:
-    pass

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import ctypes
+import importlib.metadata
 import math
 
 import boost_histogram as bh
 import numpy as np
+import packaging.version
 import pytest
 from pytest import approx
 
@@ -370,6 +372,22 @@ def test_general_project():
 
     with pytest.raises(Exception):
         h.project("G", "H")
+
+
+@pytest.mark.skipif(
+    packaging.version.Version(importlib.metadata.version("boost_histogram"))
+    < packaging.version.Version("1.8"),
+    reason="flow= requires boost-histogram 1.8+",
+)
+def test_general_project_flow():
+    h = Hist(
+        axis.Regular(4, 0, 4, name="x"),
+        axis.Regular(4, 0, 4, name="y"),
+    )
+    h.fill(x=[1, 2, -1], y=[1, 2, 9])
+
+    assert h.project("x").sum(flow=True) == 3
+    assert h.project("x", flow=False).sum(flow=True) == 2
 
 
 def test_general_index_access():

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-import importlib.metadata
-
 import numpy as np
-import packaging.version
 import pytest
 
 import hist
 from hist.serialization import from_uhi, to_uhi
 
 bhs = pytest.importorskip("boost_histogram.serialization")
-
-BHV = packaging.version.Version(importlib.metadata.version("boost_histogram"))
-BHMETADATA = packaging.version.Version("1.6.1") <= BHV
 
 
 @pytest.mark.parametrize(
@@ -40,9 +34,8 @@ def test_simple_to_dict(storage_type: hist.storage.Storage, expected_type: str) 
     assert data["axes"][0]["underflow"]
     assert data["axes"][0]["overflow"]
     assert not data["axes"][0]["circular"]
-    if BHMETADATA:
-        assert data["axes"][0]["metadata"]["name"] == "x"
-        assert data["axes"][0]["metadata"]["label"] == "X"
+    assert data["axes"][0]["metadata"]["name"] == "x"
+    assert data["axes"][0]["metadata"]["label"] == "X"
     assert data["storage"]["type"] == expected_type
     assert data["storage"]["values"] == pytest.approx(np.zeros(12))
     assert data["uhi_schema"] == 1
@@ -77,8 +70,7 @@ def test_mean_to_dict() -> None:
     )
     data = to_uhi(h)
 
-    if BHMETADATA:
-        assert data["metadata"]["name"] == "hi"
+    assert data["metadata"]["name"] == "hi"
     assert data["axes"][0]["type"] == "category_str"
     assert data["axes"][0]["categories"] == ["one", "two", "three"]
     assert data["axes"][0]["flow"]
@@ -149,9 +141,7 @@ def test_round_trip_simple(storage_type: hist.storage.Storage) -> None:
     data = to_uhi(h)
     h2 = from_uhi(data)
 
-    if BHMETADATA and isinstance(
-        storage_type, (hist.storage.Int64, hist.storage.Double)
-    ):
+    if isinstance(storage_type, (hist.storage.Int64, hist.storage.Double)):
         assert h._hist == h2._hist
         assert h == h2
 
@@ -219,8 +209,7 @@ def test_uhi_direct_conversion():
     )
     uhi_dict = h._to_uhi_()
     h2 = hist.Hist(uhi_dict)
-    if BHMETADATA:
-        assert h == h2
+    assert h == h2
 
 
 def test_round_trip_native() -> None:
@@ -232,9 +221,7 @@ def test_round_trip_native() -> None:
     data = to_uhi(h)
     h2 = from_uhi(data)
 
-    if BHMETADATA:
-        assert h == h2
-
+    assert h == h2
     assert isinstance(h2.axes[0], hist.axis.Integer)
     assert h2.storage_type is hist.storage.AtomicInt64
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,25 +1,13 @@
 from __future__ import annotations
 
-import importlib.metadata
-
-import packaging.version
-
 import hist
 
 
 def test_has_multi_cell():
-    bh_version = packaging.version.Version(
-        importlib.metadata.version("boost_histogram")
-    )
-    if bh_version >= packaging.version.Version("1.7"):
-        assert "MultiCell" in repr(hist.storage.MultiCell)
+    assert "MultiCell" in repr(hist.storage.MultiCell)
 
 
 def test_has_multi_cell_quick_construct():
-    bh_version = packaging.version.Version(
-        importlib.metadata.version("boost_histogram")
-    )
-    if bh_version >= packaging.version.Version("1.7"):
-        h = hist.new.Regular(10, 0, 1).MultiCell(2)
-        assert h.storage_type.__name__ == "MultiCell"
-        assert h.values().shape == (2, 10)
+    h = hist.new.Regular(10, 0, 1).MultiCell(2)
+    assert h.storage_type.__name__ == "MultiCell"
+    assert h.values().shape == (2, 10)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Raise the boost-histogram requirement to `>=1.7,<1.9` and remove the pre-1.7 workarounds: the conditional `MultiCell` import/quick-construct guard and the version-gated UHI metadata assertions in the tests. The `_Histogram` subscripting shim (needs 1.7.1) and the `MultiCell(0)` repr patch (needs 1.7.2) stay.

Tests pass locally with boost-histogram 1.7.0 and 1.8.0.