### PR TITLE
feat: support Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         - "3.12"
         - "3.13"
         - "3.14"
+        - "3.15"
 
     name: Check Python ${{ matrix.python-version }}
     steps:
@@ -53,15 +54,26 @@ jobs:
       run: uv venv
 
     - name: Install package
+      if: matrix.python-version != '3.15'
       run: uv pip install -e . --group test --group dask
 
+    - name: Install package (core only)
+      # scipy, iminuit, awkward, dask, and matplotlib do not support 3.15 yet
+      if: matrix.python-version == '3.15'
+      run: uv pip install -e . pytest packaging
+
     - name: Test package
-      run: .venv/bin/python -m pytest
+      # pytest-mpl needs matplotlib, so it can't be required on 3.15
+      run: >
+        .venv/bin/python -m pytest
+        ${{ matrix.python-version == '3.15' && '-o required_plugins=' || '' }}
 
     - name: Install plotting requirements too
+      if: matrix.python-version != '3.15'
       run: uv pip install -e . --group plot
 
     - name: Test plotting too
+      if: matrix.python-version != '3.15'
       # mpl image baselines track matplotlib 3.11; Python 3.10 stays on 3.10.x
       # (3.11 dropped 3.10), so only pixel-compare on 3.11+.
       run: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-import matplotlib as mpl
 import pytest
 
-mpl.use("Agg")
+try:
+    import matplotlib as mpl
 
-mpl.use("Agg")
+    mpl.use("Agg")
+except ModuleNotFoundError:
+    pass
 
 from hist import Hist, NamedHist
 from hist.hist import BaseHist


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Add the Python 3.15 classifier and test 3.15 in CI. Only numpy, boost-histogram, and the pure-Python dependencies have 3.15 wheels, so the 3.15 job installs the core package only (no plot, fit, awkward, or dask groups) and clears `required_plugins` (pytest-mpl cannot load without matplotlib). The unconditional matplotlib import in `tests/conftest.py` is now guarded so the core suite runs without it.

Core suite verified locally on 3.15.0b4: 232 passed, 6 skipped.