### PR TITLE
fix: require histoprint 2.3.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 requires-python = ">=3.10"
 dependencies = [
     "boost-histogram>=1.7,<1.9",
-    "histoprint>=2.2.0",
+    "histoprint>=2.3.0",
     'numpy>=1.21.3',
     'packaging>=23',
     'typing-extensions>=4;python_version<"3.11"',


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `Check minimums` job fails at collection: histoprint 2.2.0 (the pinned minimum) calls the deprecated `click.get_text_stream` at import time, and click 8.3+ makes a `DeprecationWarning` there. The test suite treats warnings as errors, so `import hist` fails.

histoprint 2.3.0 removed that call, so the minimum is now `>=2.3.0`.