### PR TITLE
fix: keep name and label when copying a histogram

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -197,8 +197,11 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         if data is not None:
             self[...] = data
 
-        self.name = name  # pylint: disable=assigning-non-slot
-        self.label = label  # pylint: disable=assigning-non-slot
+        # Keep name/label copied from an input histogram unless overridden
+        if name is not None or "name" not in self.__dict__:
+            self.name = name  # pylint: disable=assigning-non-slot
+        if label is not None or "label" not in self.__dict__:
+            self.label = label  # pylint: disable=assigning-non-slot
 
     def _generate_axes_(self) -> NamedAxesTuple:
         """

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1049,3 +1049,17 @@ def test_fill_missing_axis_reports_axis_name():
 
     with pytest.raises(TypeError):
         h.fill(x=[0.1, 0.2])
+
+
+def test_copy_keeps_name_label() -> None:
+    h = Hist(axis.Regular(4, 0, 1), name="n", label="l")
+    h2 = Hist(h)
+    assert h2.name == "n"
+    assert h2.label == "l"
+    h3 = Hist(h, name="x")
+    assert h3.name == "x"
+    assert h3.label == "l"
+    h4 = Hist(h, label="y")
+    assert h4.name == "n"
+    assert h4.label == "y"
+    assert Hist._from_uhi_(h._to_uhi_()).name == "n"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Hist(other)` reset `name` and `label` to `None`, so copies and UHI round-trips (`Hist._from_uhi_`) lost the histogram name. The constructor now keeps the values from the input histogram unless `name=` or `label=` is given. Adds a regression test.