### PR TITLE
feat: accept objects with _to_uhi_ in the constructor

### DIFF
--- a/src/hist/basehist.py
+++ b/src/hist/basehist.py
@@ -160,6 +160,14 @@ class BaseHist(_Histogram[S], Generic[S], metaclass=MetaConstructor, family=hist
         # Support raw Quick Construct being accidentally passed in
         args = tuple(ax for ax in process_mistaken_quick_construct(args))
 
+        # Remove when boost-histogram 1.8.2+ is required; it does this itself
+        if (
+            len(args) == 1
+            and not isinstance(args[0], bh.Histogram)
+            and hasattr(args[0], "_to_uhi_")
+        ):
+            args = (args[0]._to_uhi_(),)  # type: ignore[union-attr]
+
         if isinstance(storage, str):
             storage_str = storage.title()
             if storage_str == "Atomicint64":

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -239,3 +239,27 @@ def test_round_trip_clean() -> None:
 
     assert isinstance(h2.axes[0], hist.axis.Regular)
     assert h2.storage_type is hist.storage.Int64
+
+
+def test_uhi_protocol_object_conversion() -> None:
+    class Wrapper:
+        def __init__(self, h: hist.Hist) -> None:
+            self._hist = h
+
+        def _to_uhi_(self) -> dict:
+            return to_uhi(self._hist)
+
+    h = hist.Hist(
+        hist.axis.Regular(3, 0, 1, name="x"),
+        storage=hist.storage.Int64(),
+        name="n",
+        label="L",
+    )
+    h.fill([0.1, 0.2, 0.9])
+
+    h2 = hist.Hist(Wrapper(h))
+
+    assert h == h2
+    assert h2.axes[0].name == "x"
+    assert h2.name == "n"
+    assert h2.label == "L"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`hist.Hist(obj)` now accepts any object with a `_to_uhi_` method, mirroring boost-histogram#1191. The object is converted to its UHI dict before boost-histogram sees it; `bh.Histogram` instances keep the existing copy path.

The check is temporary and marked for removal once boost-histogram 1.8.2+ is required, since it does the same thing itself.
