### PR TITLE
feat(docs): add llms.txt and Markdown page versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
+    "sphinx_llm.txt",
     "sphinxcontrib.programoutput",
 ]
 
@@ -49,6 +50,15 @@ exclude_patterns = [
     "banner_slides.md",
     "build",
 ]
+
+
+# -- Options for LLM-friendly output -----------------------------------------
+
+# The default is the full README, which is too long for the summary block
+llms_txt_description = (
+    "Documentation of Hist, an analysis-focused histogram library built on"
+    " boost-histogram, with named axes, quick construction, and plotting."
+)
 
 
 intersphinx_mapping = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description: Hist is an analysis-focused histogram library built on
+      boost-histogram, with named axes, quick construction, and plotting.
+
 .. image:: _images/histlogo.png
    :width: 60%
    :alt: Hist logo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ docs = [
     "pillow",
     "uncertainties>=3",
     "myst_parser>=0.14",
+    "sphinx-llm",
 ]
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds LLM-friendly docs output with NVIDIA's `sphinx-llm` (`sphinx_llm.txt` extension). It runs the markdown builder alongside the HTML build and merges the results, so it is one extension and one build:

- `llms.txt` — sitemap with a one-line description per page.
- `llms-full.txt` — all docs in one file.
- `<page>.html.md` and `<page>.md` next to each `<page>.html`.

`llms_txt_description` is set because the default summary is the full README. A `meta` description in `index.rst` gives `llms.txt` a description for the index page.

Ported from scikit-hep/uhi#252.